### PR TITLE
fix: spreadsheet css had margin causing overflow

### DIFF
--- a/admin/app/assets/stylesheets/app.scss
+++ b/admin/app/assets/stylesheets/app.scss
@@ -112,8 +112,6 @@ details summary {
 }
 
 .spreadsheet {
-  margin-bottom: -$gutter;
-
   th,
   .table-field-index {
     background: $grey-4;


### PR DESCRIPTION
Bad: 

![image](https://user-images.githubusercontent.com/626664/44012759-b33fbad8-9f04-11e8-8069-6e6b8b86038f.png)

Bad 2:

![image](https://user-images.githubusercontent.com/626664/44012760-bb1493aa-9f04-11e8-85f7-97066b2544b7.png)
