### PR TITLE
feat(password-req): set min password length to 8

### DIFF
--- a/admin/app/main/forms.py
+++ b/admin/app/main/forms.py
@@ -146,7 +146,7 @@ def international_phone_number(label='Mobile number'):
 def password(label='Password'):
     return PasswordField(label,
                          validators=[DataRequired(message='Can’t be empty'),
-                                     Length(4, 255, message='Must be at least 8 characters'),
+                                     Length(8, 255, message='Must be at least 8 characters'),
                                      Blacklist(message='Choose a password that’s harder to guess')])
 
 


### PR DESCRIPTION
ISM two factor requires a minimum of 6 characters. this just reverts us
back to what UK had which exceeds ISM requirement.

https://acsc.gov.au/publications/Information_Security_Manual_2017_Controls.pdf

page 194, 195