### PR TITLE
fix(manifest): buildpack->buildpacks

### DIFF
--- a/admin/manifest-dev.yml
+++ b/admin/manifest-dev.yml
@@ -1,6 +1,6 @@
----
 defaults: &defaults
-  buildpack: python_buildpack
+  buildpacks:
+    - python_buildpack
   instances: 1
   memory: 1G
   services:
@@ -8,14 +8,14 @@ defaults: &defaults
     - notify-admin
     - aws
   env: &defaults_env
-    RUNNER: './vcapenvwrapper --root notify-shared --root notify-admin --root aws'
+    RUNNER: "./vcapenvwrapper --root notify-shared --root notify-admin --root aws"
     NOTIFY_ENVIRONMENT: production
   command: make run-gunicorn
 
 applications:
-- name: notify
-  <<: *defaults
-  env:
-    <<: *defaults_env
-    ADMIN_BASE_URL: https://notify-((stg)).apps.y.cld.gov.au
-    API_HOST_NAME: https://notify-api-((stg)).apps.y.cld.gov.au
+  - name: notify
+    <<: *defaults
+    env:
+      <<: *defaults_env
+      ADMIN_BASE_URL: https://notify-((stg)).apps.y.cld.gov.au
+      API_HOST_NAME: https://notify-api-((stg)).apps.y.cld.gov.au

--- a/admin/manifest.yml
+++ b/admin/manifest.yml
@@ -1,6 +1,6 @@
----
 defaults: &defaults
-  buildpack: python_buildpack
+  buildpacks:
+    - python_buildpack
   instances: 1
   memory: 1G
   services:
@@ -8,17 +8,17 @@ defaults: &defaults
     - notify-admin
     - aws
   env: &defaults_env
-    RUNNER: './vcapenvwrapper --root notify-shared --root notify-admin --root aws'
+    RUNNER: "./vcapenvwrapper --root notify-shared --root notify-admin --root aws"
     NOTIFY_ENVIRONMENT: production
   command: make run-gunicorn
 
 applications:
-- name: notify
-  <<: *defaults
-  routes:
-    - route: notify.gov.au
-    - route: notify.apps.b.cld.gov.au
-  env:
-    <<: *defaults_env
-    ADMIN_BASE_URL: https://notify.gov.au
-    API_HOST_NAME: https://rest-api.notify.gov.au
+  - name: notify
+    <<: *defaults
+    routes:
+      - route: notify.gov.au
+      - route: notify.apps.b.cld.gov.au
+    env:
+      <<: *defaults_env
+      ADMIN_BASE_URL: https://notify.gov.au
+      API_HOST_NAME: https://rest-api.notify.gov.au

--- a/api/manifest-dev.yml
+++ b/api/manifest-dev.yml
@@ -1,6 +1,6 @@
----
 defaults: &defaults
-  buildpack: python_buildpack
+  buildpacks:
+    - python_buildpack
   instances: 1
   memory: 1G
   services:
@@ -12,7 +12,7 @@ defaults: &defaults
     - twilio
     - smtp
   env:
-    RUNNER: './vcapenvwrapper --root notify-shared --root notify-api --root aws --root telstra --root twilio --root smtp'
+    RUNNER: "./vcapenvwrapper --root notify-shared --root notify-api --root aws --root telstra --root twilio --root smtp"
     FLASK_APP: application.py
     NOTIFY_ENVIRONMENT: production
     ADMIN_BASE_URL: https://notify-((stg)).apps.y.cld.gov.au
@@ -20,11 +20,11 @@ defaults: &defaults
     CREATE_ADMIN_USER: true
 
 applications:
-- name: notify-api-((stg))
-  <<: *defaults
-  command: make run-production
-- name: notify-celery-((stg))
-  <<: *defaults
-  health-check-type: process
-  no-route: true
-  command: make run-celery
+  - name: notify-api-((stg))
+    <<: *defaults
+    command: make run-production
+  - name: notify-celery-((stg))
+    <<: *defaults
+    health-check-type: process
+    no-route: true
+    command: make run-celery

--- a/api/manifest.yml
+++ b/api/manifest.yml
@@ -1,6 +1,6 @@
----
 defaults: &defaults
-  buildpack: python_buildpack
+  buildpacks:
+    - python_buildpack
   instances: 1
   memory: 1G
   services:
@@ -12,21 +12,21 @@ defaults: &defaults
     - twilio
     - smtp
   env:
-    RUNNER: './vcapenvwrapper --root notify-shared --root notify-api --root aws --root telstra --root twilio --root smtp'
+    RUNNER: "./vcapenvwrapper --root notify-shared --root notify-api --root aws --root telstra --root twilio --root smtp"
     FLASK_APP: application.py
     NOTIFY_ENVIRONMENT: production
     ADMIN_BASE_URL: https://notify.gov.au
     API_HOST_NAME: https://rest-api.notify.gov.au
 
 applications:
-- name: notify-api
-  <<: *defaults
-  command: make run-production
-  routes:
-    - route: rest-api.notify.gov.au
-    - route: notify-api.apps.b.cld.gov.au
-- name: notify-celery
-  <<: *defaults
-  health-check-type: process
-  no-route: true
-  command: make run-celery
+  - name: notify-api
+    <<: *defaults
+    command: make run-production
+    routes:
+      - route: rest-api.notify.gov.au
+      - route: notify-api.apps.b.cld.gov.au
+  - name: notify-celery
+    <<: *defaults
+    health-check-type: process
+    no-route: true
+    command: make run-celery

--- a/status/manifest.yml
+++ b/status/manifest.yml
@@ -1,17 +1,17 @@
----
 defaults: &defaults
-  buildpack: ruby_buildpack
+  buildpacks:
+    - ruby_buildpack
   instances: 1
   memory: 1G
   services:
     - notify-mysql-status
   env:
-    RUNNER: ''
+    RUNNER: ""
     PRODUCTION: true
 
 applications:
-- name: notify-status
-  <<: *defaults
-  routes:
-    - route: status.notify.gov.au
-    - route: notify-status.apps.b.cld.gov.au
+  - name: notify-status
+    <<: *defaults
+    routes:
+      - route: status.notify.gov.au
+      - route: notify-status.apps.b.cld.gov.au


### PR DESCRIPTION
CF now prefers using buildpacks instead of buildpack in the manifest
file.

Also formatted the YAML file using prettier.

The error when pushing was:

Deprecation warning: Use of 'buildpack' attribute in manifest is
deprecated in favor of 'buildpacks'. Please see
http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#deprecated
for alternatives and other app manifest deprecations. This feature
will be removed in the future.