### PR TITLE
feat(deploy): use ZDT for deploy branches too

### DIFF
--- a/admin/Makefile
+++ b/admin/Makefile
@@ -91,7 +91,7 @@ deploy: vendor requirements.txt ## Deploy admin to cloudfoundry
 	$(CF) zero-downtime-push $(APP) -f manifest.yml
 
 deploy-dev: manifest-vars-$(STG).yml vendor requirements.txt ## Deploy admin to cloudfoundry
-	$(CF) push $(APP)-$(STG) -f manifest-dev.yml --vars-file $<
+	$(CF) zero-downtime-push $(APP)-$(STG) -f manifest-dev.yml --vars-file $<
 
 clean:
 	-rm -r vendor

--- a/api/Makefile
+++ b/api/Makefile
@@ -140,7 +140,7 @@ deploy: vendor requirements.txt ## Deploy prod application
 	$(CF) zero-downtime-push $(APP) -f manifest.yml
 
 deploy-dev: manifest-vars-$(STG).yml vendor requirements.txt
-	$(CF) push $(APP)-$(STG) -f manifest-dev.yml --vars-file $<
+	$(CF) zero-downtime-push $(APP)-$(STG) -f manifest-dev.yml --vars-file $<
 
 deploy-celery:
 	APP=notify-celery $(MAKE) deploy


### PR DESCRIPTION
This is what prod uses. By not using this for feature branches,
we can break master because changes in manifest.yml, for example
are not tested.