### PR TITLE
Adding CREATE_ADMIN_USER=false to .env.sample

### DIFF
--- a/api/.env.sample
+++ b/api/.env.sample
@@ -27,4 +27,6 @@ TWILIO_ACCOUNT_SID=
 TWILIO_AUTH_TOKEN=
 TWILIO_FROM_NUMBER=
 
+CREATE_ADMIN_USER=false
+
 SQLALCHEMY_TEST_DATABASE_URI="postgresql://postgres@localhost:5420/test_notification_api"


### PR DESCRIPTION
Will be needed locally when migration scripts are run (e.g. running tests)