### PR TITLE
feat(twilio): don't set cb URL if host is empty

### DIFF
--- a/api/app/clients/sms/twilio.py
+++ b/api/app/clients/sms/twilio.py
@@ -57,7 +57,7 @@ class TwilioSMSClient(SmsClient):
 
         start_time = monotonic()
         from_number = self._from_number
-        callback_url = "{}/notifications/sms/twilio/{}".format(self._callback_notify_url_host, reference)
+        callback_url = "{}/notifications/sms/twilio/{}".format(self._callback_notify_url_host, reference) if self._callback_notify_url_host else ""
         try:
             message = self._client.messages.create(
                 to=to,


### PR DESCRIPTION
In development, the Twilio callback URL can end up with an empty host,
so this commit ensures that it's not passed to Twilio of the host is
empty.