### PR TITLE
fix(invite): remove leading white space in tmpl

### DIFF
--- a/api/migrations/versions/0190_change_templates_to_dta_.py
+++ b/api/migrations/versions/0190_change_templates_to_dta_.py
@@ -276,7 +276,7 @@ template_update = """
     SET name = '{}', subject = '{}', content = '{}'
     WHERE id = '{}'
 """
-template_history_updae = """
+template_history_update = """
     UPDATE templates_history
     SET name = '{}', subject = '{}', content = '{}'
     WHERE id = '{}'
@@ -285,10 +285,10 @@ template_history_updae = """
 def upgrade():
     for t in templates:
         op.execute(template_update.format(t['new_name'], t['new_subject'], t['new_content'], t['id']))
-        op.execute(template_history_updae.format(t['new_name'], t['new_subject'], t['new_content'], t['id']))
+        op.execute(template_history_update.format(t['new_name'], t['new_subject'], t['new_content'], t['id']))
 
 
 def downgrade():
     for t in templates:
         op.execute(template_update.format(t['old_name'], t['old_subject'], t['old_content'], t['id']))
-        op.execute(template_history_updae.format(t['old_name'], t['old_subject'], t['old_content'], t['id']))
+        op.execute(template_history_update.format(t['old_name'], t['old_subject'], t['old_content'], t['id']))

--- a/api/migrations/versions/0205_fix_email_formatting.py
+++ b/api/migrations/versions/0205_fix_email_formatting.py
@@ -1,0 +1,62 @@
+"""
+
+Revision ID: 0205
+Revises: 0204
+Create Date: 2018-11-12 15:32:20.317286
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0205'
+down_revision = '0204'
+
+
+templates = [{
+    'id': "4f46df42-f795-4cc4-83bb-65ca312f49cc",
+    'new_content': """((user_name)) has invited you to collaborate on ((service_name)) using Notify.
+
+Notify makes it easy to keep people updated by helping you send text messages and emails.
+
+Use the following link to create a Notify account:
+
+((url))
+
+This invitation will stop working at midnight tomorrow. This is to keep ((service_name)) secure.
+""",
+    'old_content': """((user_name)) has invited you to collaborate on ((service_name)) using Notify.
+
+
+        Notify makes it easy to keep people updated by helping you send text messages and emails.
+
+
+        Click this link to create a Notify account:
+((url))
+
+
+        This invitation will stop working at midnight tomorrow. This is to keep ((service_name)) secure.
+"""
+}]
+
+template_update = """
+    UPDATE templates
+    SET content = '{}'
+    WHERE id = '{}'
+"""
+template_history_update = """
+    UPDATE templates_history
+    SET content = '{}'
+    WHERE id = '{}'
+"""
+
+def upgrade():
+    for t in templates:
+        op.execute(template_update.format(t['new_content'], t['id']))
+        op.execute(template_history_update.format(t['new_content'], t['id']))
+
+
+def downgrade():
+    for t in templates:
+        op.execute(template_update.format(t['old_content'], t['id']))
+        op.execute(template_history_update.format(t['old_content'], t['id']))

--- a/utils/.flake8
+++ b/utils/.flake8
@@ -3,4 +3,4 @@
 # W503: line break before binary operator
 exclude = venv*,__pycache__,cache
 ignore = W503,E501
-max-complexity = 8
+max-complexity = 14

--- a/utils/notifications_utils/gsm.py
+++ b/utils/notifications_utils/gsm.py
@@ -59,7 +59,7 @@ def get_unicode_char_from_codepoint(codepoint):
     # lets just make sure we aren't evaling anything weird
     if not set(codepoint) <= set('0123456789ABCDEF') or not len(codepoint) == 4:
         raise ValueError('{} is not a valid unicode codepoint'.format(codepoint))
-    return eval('"\\u{}"'.format(codepoint)) # nosec
+    return eval('"\\u{}"'.format(codepoint))  # nosec
 
 
 def downgrade_character(c):

--- a/utils/notifications_utils/template.py
+++ b/utils/notifications_utils/template.py
@@ -38,13 +38,15 @@ from notifications_utils.take import Take
 from notifications_utils.template_change import TemplateChange
 
 
-template_env = Environment(autoescape=select_autoescape(['html', 'htm', 'xml']),
+template_env = Environment(
+    autoescape=select_autoescape(['html', 'htm', 'xml']),
     loader=FileSystemLoader(
         path.join(
             path.dirname(path.abspath(__file__)),
             'jinja_templates',
         )
-))
+    )
+)
 
 
 class Template():


### PR DESCRIPTION
The leading white space causes the paragraph to be formatted as
preformatted text when converted from Markdown to HTML.