### PR TITLE
Remove gov.uk from list of government email domains + fix css

### DIFF
--- a/admin/app/assets/stylesheets/govuk-template.scss
+++ b/admin/app/assets/stylesheets/govuk-template.scss
@@ -952,8 +952,8 @@ button:focus {
 }
 
 #content .bottom-gutter,
-#content .bottom-gutter-2-3 {
-  & > * {
+#content .bottom-gutter-2-3  {
+  & > *:not(.banner-default-with-tick) {
     padding-left: 0;
   }
 }

--- a/admin/app/assets/stylesheets/govuk-template.scss
+++ b/admin/app/assets/stylesheets/govuk-template.scss
@@ -952,8 +952,8 @@ button:focus {
 }
 
 #content .bottom-gutter,
-#content .bottom-gutter-2-3  {
-  & > *:not(.banner-default-with-tick) {
+#content .bottom-gutter-2-3 {
+  & > * {
     padding-left: 0;
   }
 }

--- a/admin/app/email_domains.yml
+++ b/admin/app/email_domains.yml
@@ -1,4 +1,2 @@
 ---
 - gov.au
-# TODO: remove gov.uk
-- gov.uk


### PR DESCRIPTION
Sanity tested the following:

- login with an existing .gov.au login
- send an invite to a .gov.au email address
- send an SMS 
- send an email
- create a new user with .gov.au email address
