### PR TITLE
report: exclude services created by platform admin

### DIFF
--- a/api/app/dao/services_dao.py
+++ b/api/app/dao/services_dao.py
@@ -89,6 +89,7 @@ def dao_fetch_trial_services_data():
         Organisation.name.label("organisation_name"),
         Service.organisation_type,
         Service.name.label("service_name"),
+        Service.count_as_live,
         case([
             (this_year_ft_billing.c.notification_type == 'email', func.sum(this_year_ft_billing.c.notifications_sent))
         ], else_=0).label("email_totals"),
@@ -103,6 +104,7 @@ def dao_fetch_trial_services_data():
     ).outerjoin(
         this_year_ft_billing, Service.id == this_year_ft_billing.c.service_id
     ).filter(
+        Service.count_as_live.is_(True),
         Service.active.is_(True),
         Service.restricted.is_(True),
     ).group_by(
@@ -110,6 +112,7 @@ def dao_fetch_trial_services_data():
         Organisation.name,
         Service.organisation_type,
         Service.name,
+        Service.count_as_live,
         this_year_ft_billing.c.notification_type
     ).order_by(
         asc(Service.name)

--- a/api/tests/app/dao/test_services_dao.py
+++ b/api/tests/app/dao/test_services_dao.py
@@ -271,6 +271,9 @@ def test_dao_fetch_trial_services_data(sample_user, mock):
     template = create_template(service=service)
     create_service(service_name='second', go_live_user=sample_user, go_live_at='2017-04-20T10:00:00')
     create_service(service_name='third', go_live_at='2016-04-20T10:00:00')
+    # This service represents one created by platform admin (hence why
+    # count_as_live is false).
+    create_service(service_name='not_live', count_as_live=False)
     # This service should be included.
     restricted_service = create_service(service_name='restricted', restricted=True)
     dao_add_service_to_organisation(service=restricted_service, organisation_id=org.id)


### PR DESCRIPTION
When a platform admin creates a service, we usually want to exclude it
from reports because it is often a test or dummy service. We can exclude
it from reports using the count_as_live field. This is set to false for
new services that are created by platform admins. Services of this
nature were already being excluded in the live services report. They are
now excluded from the trial services report too.

It's worth mentioning that count_as_live doesn't make that much sense in
the context of a trial service (since it's not live). We leave the field
named as such for now to keep it aligned with the original GDS codebase.
At the time of writing it appears that a better name is possibly
something like 'include in reports'.