### PR TITLE
api: fix bad task name from refactor

### DIFF
--- a/api/app/celery/research_mode_tasks.py
+++ b/api/app/celery/research_mode_tasks.py
@@ -9,7 +9,7 @@ from notifications_utils.s3 import s3upload
 from app import notify_celery
 from app.models import SMS_TYPE
 from app.config import QueueNames
-from app.celery.process_ses_receipts_tasks import process_ses_results
+from app.celery.process_ses_receipts_tasks import process_ses_results_task
 
 temp_fail = "409000003"
 perm_fail = "409000002"
@@ -41,7 +41,7 @@ def send_email_response(reference, to):
     else:
         body = ses_notification_callback(reference)
 
-    process_ses_results.apply_async([body], queue=QueueNames.RESEARCH_MODE)
+    process_ses_results_task.apply_async([body], queue=QueueNames.RESEARCH_MODE)
 
 
 def make_request(notification_type, provider, notification_id, data, headers):

--- a/api/tests/app/celery/test_research_mode_tasks.py
+++ b/api/tests/app/celery/test_research_mode_tasks.py
@@ -50,7 +50,7 @@ def test_make_twilio_callback(notify_api, rmock, phone_number):
 
 
 def test_make_ses_callback(notify_api, mocker):
-    mock_task = mocker.patch('app.celery.research_mode_tasks.process_ses_results')
+    mock_task = mocker.patch('app.celery.research_mode_tasks.process_ses_results_task')
     some_ref = str(uuid.uuid4())
 
     send_email_response(reference=some_ref, to="test@test.com")


### PR DESCRIPTION
In a rename the call should have been renamed to
process_ses_results_task.