### PR TITLE
template: prefer "history" to "versions"

### DIFF
--- a/admin/app/templates/views/templates/choose_history.html
+++ b/admin/app/templates/views/templates/choose_history.html
@@ -1,11 +1,11 @@
 {% extends "withnav_template.html" %}
 
 {% block service_page_title %}
-  Previous versions
+  History of changes
 {% endblock %}
 
 {% block maincolumn_content %}
-  <h1 class="heading-large">Previous versions</h1>
+  <h1 class="heading-large">History of changes</h1>
   <div class="grid-row">
     {% for template in versions %}
       {% with show_title=True %}

--- a/admin/app/templates/views/templates/template.html
+++ b/admin/app/templates/views/templates/template.html
@@ -59,7 +59,7 @@
     {% if template._template.updated_at %}
       <h2 class="heading-small bottom-gutter-2-3 heading-inline">Last edited {{ template._template.updated_at|format_delta }}</h2>
       &emsp;
-      <a href="{{ url_for('.view_template_versions', service_id=current_service.id, template_id=template.id) }}">See previous versions</a>
+      <a href="{{ url_for('.view_template_versions', service_id=current_service.id, template_id=template.id) }}">See history of changes</a>
       &emsp;
       <br/>
     {% endif %}


### PR DESCRIPTION
When viewing a templates versions, the heading copy implied that you
were only looking at previous versions of the template when in fact the
topmost version was also the latest.

By using "history of changes" instead, it should be clearer that you're
looking at the full history of changes to the template.