### PR TITLE
admin: add sticky footer

### DIFF
--- a/admin/app/assets/javascripts/fullscreenTable.js
+++ b/admin/app/assets/javascripts/fullscreenTable.js
@@ -24,11 +24,13 @@
         .on('scroll', this.maintainHeight);
 
       if (
-        window.GOVUK.stopScrollingAtFooter &&
-        window.GOVUK.stopScrollingAtFooter.updateFooterTop
+        window.GOVUK.stickAtBottomWhenScrolling &&
+        window.GOVUK.stickAtBottomWhenScrolling.recalculate
       ) {
-        window.GOVUK.stopScrollingAtFooter.updateFooterTop();
+        window.GOVUK.stickAtBottomWhenScrolling.recalculate();
       }
+
+      this.maintainWidth();
 
     };
 

--- a/admin/app/assets/javascripts/main.js
+++ b/admin/app/assets/javascripts/main.js
@@ -1,6 +1,7 @@
 $(() => $("time.timeago").timeago());
 
 $(() => GOVUK.stickAtTopWhenScrolling.init());
+$(() => GOVUK.stickAtBottomWhenScrolling.init());
 
 $(() => GOVUK.modules.start());
 

--- a/admin/app/assets/javascripts/stick-to-window-when-scrolling.js
+++ b/admin/app/assets/javascripts/stick-to-window-when-scrolling.js
@@ -1,0 +1,963 @@
+;(function (global) {
+  'use strict';
+
+  var $ = global.jQuery;
+  var GOVUK = global.GOVUK || {};
+  var _mode = 'default';
+
+  // Constructor to make objects representing the area sticky elements can scroll in
+  var ScrollArea = function (el, edge, selector) {
+    var $el = el.$fixedEl;
+    var $scrollArea = $el.closest('.sticky-scroll-area');
+
+    $scrollArea = $scrollArea.length ? $scrollArea : $el.parent();
+
+    this._els = [el];
+    this.edge = edge;
+    this.selector = selector;
+    this.node = $scrollArea.get(0);
+    this.setEvents();
+  };
+  ScrollArea.prototype.addEl = function (el) {
+    this._els.push(el);
+  };
+  ScrollArea.prototype.hasEl = function (el) {
+    return $.inArray(el, this._els) !== -1;
+  };
+  ScrollArea.prototype.updateEls = function (usedEls) {
+    this._els = usedEls;
+  };
+  ScrollArea.prototype.setEvents = function () {
+    this.node.addEventListener('focus', this.focusHandler.bind(this), true);
+    $(this.node).on('keyup', 'textarea', this.focusHandler.bind(this));
+  };
+  ScrollArea.prototype.removeEvents = function () {
+    this.node.removeEventListener('focus', this.focusHandler.bind(this));
+    $(this.node).find('textarea').off('keyup', 'textarea', this.focusHandler.bind(this));
+  };
+  ScrollArea.prototype.getFocusedDetails = {
+    forElement: function ($focusedElement) {
+      var focused = {
+        'top': $focusedElement.offset().top,
+        'height': $focusedElement.outerHeight(),
+        'type': 'element'
+      };
+      focused.bottom = focused.top + focused.height;
+
+      return focused;
+    },
+    forCaret: function (evt) {
+      var textarea = evt.target;
+      var caretCoordinates = window.getCaretCoordinates(textarea, textarea.selectionEnd);
+      var focused = {
+        'top': $(textarea).offset().top + caretCoordinates.top,
+        'height': caretCoordinates.height,
+        'type': 'caret'
+      };
+
+      focused.bottom = focused.top + focused.height;
+
+      return focused;
+    }
+  };
+  ScrollArea.prototype.focusHandler = function (e) {
+    var $focusedElement = $(document.activeElement);
+    var nodeName = $focusedElement.get(0).nodeName.toLowerCase();
+    var endOfFurthestEl = focusOverlap.endOfFurthestEl(this._els, this.edge);
+    var isInSticky = function () {
+      return $focusedElement.closest(this.selector).length > 0;
+    }.bind(this);
+    var focused;
+    var overlap;
+
+    // if textarea is focused, we care about checking the caret, not the whole element
+    if (nodeName === 'textarea') {
+      focused = this.getFocusedDetails.forCaret(e);
+    } else {
+      if (isInSticky()) { return; }
+      focused = this.getFocusedDetails.forElement($focusedElement);
+    }
+
+    overlap = focusOverlap.getOverlap(focused, this.edge, endOfFurthestEl);
+
+    if (overlap > 0) {
+      focusOverlap.adjustForOverlap(focused, this.edge, overlap);
+    }
+  };
+  ScrollArea.prototype.destroy = function () {
+    this.removeEvents();
+  };
+
+  // Object collecting together methods for interacting with scrollareas
+  var scrollAreas = {
+    _scrollAreas: [],
+    getAreaForEl: function (el) {
+      var loopIdx = this._scrollAreas.length;
+
+      while(loopIdx--) {
+        if (this._scrollAreas[loopIdx].hasEl(el)) {
+          return this._scrollAreas[loopIdx];
+        }
+      }
+
+      return false;
+    },
+    getAreaByEl: function (el) {
+      var matches = $.grep(this._scrollAreas, function (area) {
+        return $.inArray(el, area.els) !== -1;
+      });
+
+      return matches[0] || false;
+    },
+    addEl: function (el, edge, selector) {
+      var scrollArea = this.getAreaForEl(el);
+
+      if (!scrollArea) {
+        this._scrollAreas.push(new ScrollArea(el, edge, selector));
+      } else {
+        scrollArea.addEl(el);
+      }
+    },
+    syncEls: function (elsInDOM) {
+      var self = this;
+      var unusedAreas = [];
+
+      var getUsed = function (area) {
+        var used = [];
+
+        $.each(elsInDOM, function (elIdx, el) {
+          if (area.hasEl(el)) {
+            used.push(el);
+          }
+        });
+
+        return used;
+      };
+
+      var deleteUnused = function (idx, areaIdx) {
+        // remove any events for overlap checking bound to the scrollArea
+        self._scrollAreas[areaIdx].destroy();
+        self._scrollAreas.splice(areaIdx, 1);
+      };
+
+      // update any scroll areas with els still in the DOM and track any with none
+      $.each(this._scrollAreas, function (areaIdx, area) {
+        var used = getUsed(area);
+
+        if (!used.length) {
+          unusedAreas.push(areaIdx);
+        }
+
+        area.updateEls(used);
+      });
+
+      // delete any scroll areas with no els still in DOM
+      $.each(unusedAreas, deleteUnused);
+    }
+  };
+
+  // Object collecting together methods for stopping sticky overlapping focused elements
+  var focusOverlap = {
+    getOverlap: function (focused, edge, endOfFurthestEl) {
+      if (!endOfFurthestEl) { return 0; }
+
+      if (edge === 'top') {
+        return endOfFurthestEl - focused.top;
+      } else {
+        return focused.bottom - endOfFurthestEl;
+      }
+    },
+    endOfFurthestEl: function (els, edge) {
+      var stuckEls = $.grep(els, function (el) { return el.isStuck(); });
+      var edgeOfEl;
+      var offsets;
+
+      if (edge === 'bottom') {
+        edgeOfEl = function (el) {
+          return el.$fixedEl.offset().top;
+        };
+      } else {
+        edgeOfEl = function (el) {
+          return el.$fixedEl.offset().top + el.height;
+        };
+      }
+
+      if (!stuckEls.length) { return false; }
+
+      offsets = $.map(stuckEls, function (el) { return edgeOfEl(el); });
+
+      return offsets.reduce(function (accumulator, offset) {
+        return (accumulator < offset) ? offset: accumulator;
+      });
+    },
+    adjustForOverlap: function (focused, edge, overlap) {
+      var scrollTop = $(window).scrollTop();
+
+      // scroll so element becomes visible
+      if (edge === 'top') {
+        $(window).scrollTop(scrollTop - overlap);
+      } else {
+        $(window).scrollTop(scrollTop + overlap);
+      }
+    }
+  };
+
+  // Object collecting together methods for dealing with marking the edge of a sticky, or group of
+  // sticky elements (as seen in dialog mode)
+  var oppositeEdge = {
+    _classes: {
+      'top': 'content-fixed__top',
+      'bottom': 'content-fixed__bottom'
+    },
+    _getClassForEdge: function (edge) {
+      return this._classes[edge];
+    },
+    mark: function (sticky) {
+      var edgeClass = this._getClassForEdge(sticky.edge);
+      var els;
+
+      if (_mode === 'dialog') {
+        els = [dialog.getElementAtOppositeEnd(sticky)];
+      } else {
+        els = sticky._els;
+      }
+
+      els = $.grep(els, function (el) { return el.isStuck(); });
+
+      $.each(els, function (i, el) {
+        el.$fixedEl.addClass(edgeClass);
+      });
+    },
+    unmark: function (sticky) {
+      var edgeClass = this._getClassForEdge(sticky.edge);
+
+      $.each(sticky._els, function (i, el) {
+        el.$fixedEl.removeClass(edgeClass);
+      });
+    }
+  };
+
+  // Constructor for objects holding data for each element to have sticky behaviour
+  var StickyElement = function ($el, sticky) {
+    this._sticky = sticky;
+    this.$fixedEl = $el;
+    this._initialFixedClass = 'content-fixed-onload';
+    this._fixedClass = 'content-fixed';
+    this._appliedClass = null;
+    this._$shim = null;
+    this._stopped = false;
+    this._hasLoaded = false;
+    this._canBeStuck = true;
+    this.verticalMargins = {
+      'top': parseInt(this.$fixedEl.css('margin-top'), 10),
+      'bottom': parseInt(this.$fixedEl.css('margin-bottom'), 10),
+    };
+  };
+  StickyElement.prototype._getShimCSS = function () {
+    return {
+      'width': this.horizontalSpace + 'px',
+      'height': this.height + 'px',
+      'margin-top': this.verticalMargins.top + 'px',
+      'margin-bottom': this.verticalMargins.bottom + 'px'
+    };
+  };
+  StickyElement.prototype.stickyClass = function () {
+    return (this._sticky._initialPositionsSet) ? this._fixedClass : this._initialFixedClass;
+  };
+  StickyElement.prototype.appliedClass = function () {
+    return this._appliedClass;
+  };
+  StickyElement.prototype.removeStickyClasses = function (sticky) {
+    this.$fixedEl.removeClass([
+      this._initialFixedClass,
+      this._fixedClass
+    ].join(' '));
+  };
+  StickyElement.prototype.isStuck = function () {
+    return this._appliedClass !== null;
+  };
+  StickyElement.prototype.stick = function (sticky) {
+    this._appliedClass = this.stickyClass();
+    this.$fixedEl.addClass(this._appliedClass);
+    this._hasBeenCalled = true;
+  };
+  StickyElement.prototype.release = function (sticky) {
+    this._appliedClass = null;
+    this.removeStickyClasses(sticky);
+    this._hasBeenCalled = true;
+  };
+  // When a sticky element is moved into the 'stuck' state, a shim is inserted into the
+  // page to preserve the space the element occupies in the flow.
+  StickyElement.prototype.addShim = function (position) {
+    this._$shim = $('<div class="shim">&nbsp</div>');
+    this._$shim.css(this._getShimCSS());
+    this.$fixedEl[position](this._$shim);
+  };
+  StickyElement.prototype.removeShim = function () {
+    if (this._$shim !== null) {
+      this._$shim.remove();
+      this._$shim = null;
+    }
+  };
+  // Changes to the dimensions of a sticky element with a shim need to be passed on to the shim
+  StickyElement.prototype.updateShim = function () {
+    if (this._$shim) {
+      this._$shim.css(this._getShimCSS());
+    }
+  };
+  StickyElement.prototype.stop = function () {
+    this._stopped = true;
+  };
+  StickyElement.prototype.unstop = function () {
+    this._stopped = false;
+  };
+  StickyElement.prototype.isStopped = function () {
+    return this._stopped;
+  };
+  StickyElement.prototype.isInPage = function () {
+    var node = this.$fixedEl.get(0);
+
+    return (node === document.body) ? false : document.body.contains(node);
+  };
+  StickyElement.prototype.canBeStuck = function (val) {
+    if (val !== undefined) {
+      this._canBeStuck = val;
+    } else {
+      return this._canBeStuck;
+    }
+  };
+  StickyElement.prototype.hasLoaded = function (val) {
+    if (val !== undefined) {
+      this._hasLoaded = val;
+    } else {
+      return this._hasLoaded;
+    }
+  };
+
+  // Object collecting together methods for treating sticky elements as if they
+  // were wrapped by a dialog component
+  var dialog = {
+    hasResized: false,
+    spaceBetweenStickys: 40,
+    // we add padding of 20px around each sticky to give some space between it and the rest of the page
+    // this shouldn't apply between stickys in a stack
+    // (the in-page CSS handles this by each subsequent sticky in a sequence having margin: -40px)
+    _getPaddingBetweenEls: function (els) {
+      if (els.length <= 1) { return 0; }
+
+      return (els.length - 1) * this.spaceBetweenStickys;
+    },
+    _getTotalHeight: function (els) {
+      var reducer = function (accumulator, currentValue) {
+        return accumulator + currentValue;
+      };
+      var combinedHeight = $.map(els, function (el) { return el.height; }).reduce(reducer);
+
+      return combinedHeight - this._getPaddingBetweenEls(els);
+    },
+    _elsThatCanBeStuck: function (els) {
+      return $.grep(els, function (el) { return el.canBeStuck(); });
+    },
+    getOffsetFromEdge: function (el, sticky) {
+      var els = this._elsThatCanBeStuck(sticky._els).slice();
+      var elIdx;
+
+      // els must be arranged furtherest from window edge is stuck to first
+      // default direction is order in document
+      if (sticky.edge === 'top') {
+        els.reverse();
+      }
+
+      elIdx = els.indexOf(el);
+
+      // if next to window edge the dialog is stuck to, no offset
+      if (elIdx === (els.length - 1)) { return 0; }
+
+      // make els all those from this one to the window edge
+      els = els.slice(elIdx + 1);
+
+      // remove the space between those els and the one on the edge
+      return this._getTotalHeight(els) - this.spaceBetweenStickys;
+    },
+    getOffsetFromEnd: function (el, sticky) {
+      var els = this._elsThatCanBeStuck(sticky._els).slice();
+      var elIdx;
+
+      // els must be arranged furtherest from window edge is stuck to first
+      // default direction is order in document
+      if (sticky.edge === 'bottom') {
+        els.reverse();
+      }
+
+      elIdx = els.indexOf(el);
+
+      // if next to opposite edge to the one the dialog is stuck to, no offset
+      if (elIdx === (els.length - 1)) { return 0; }
+
+      // make els all those from this one to the window edge
+      els = els.slice(elIdx + 1);
+
+      return this._getTotalHeight(els) - this.spaceBetweenStickys;
+    },
+    // checks total height of all this._sticky elements against a height
+    // unsticks each that won't fit and marks them as unstickable
+    fitToHeight: function (sticky) {
+      var self = this;
+      var els = sticky._els.slice();
+      var height = sticky.getWindowDimensions().height;
+      var totalStickyHeight = function () {
+        return self._getTotalHeight(self._elsThatCanBeStuck(els));
+      };
+      var dialogFitsHeight = function () {
+        return totalStickyHeight() <= height;
+      };
+
+      // els must be arranged furtherest from window edge is stuck to first
+      // default direction is order in document
+      if (sticky.edge === 'top') {
+        els.reverse();
+      }
+
+      // reset elements
+      $.each(els, function (i, el) { el.canBeStuck(true); });
+
+      while (self._elsThatCanBeStuck(els).length && !dialogFitsHeight()) {
+        var currentEl = self._elsThatCanBeStuck(els)[0];
+
+        sticky.reset(currentEl);
+        currentEl.canBeStuck(false);
+
+        if (!self.hasResized) { self.hasResized = true; }
+      }
+    },
+    getElementAtStickyEdge: function (sticky) {
+      var els = this._elsThatCanBeStuck(sticky._els);
+      var idx = (sticky.edge === 'top') ? 0 : els.length - 1;
+
+      return els[idx];
+    },
+    // get element at the end opposite the sticky edge
+    getElementAtOppositeEnd: function (sticky) {
+      var els = this._elsThatCanBeStuck(sticky._els);
+      var idx = (sticky.edge === 'top') ? els.length - 1 : 0;
+
+      return els[idx];
+    },
+    getInPageEdgePosition: function (sticky) {
+      return this.getElementAtStickyEdge(sticky).inPageEdgePosition;
+    },
+    getHeight: function (els) {
+      return this._getTotalHeight(this._elsThatCanBeStuck(els));
+    },
+    adjustForResize: function (sticky) {
+      var windowHeight = sticky.getWindowDimensions().height;
+
+      if (sticky.edge === 'top') {
+        $(window).scrollTop(this.getInPageEdgePosition(sticky));
+      } else {
+        $(window).scrollTop(this.getInPageEdgePosition(sticky) - windowHeight);
+      }
+
+      this.hasResized = false;
+    },
+    releaseEl: function (el, sticky) {
+      el.$fixedEl.css(sticky.edge, '');
+    }
+  };
+
+  // Constructor for objects collecting together all generic behaviour for controlling the state of
+  // sticky elements
+  var Sticky = function (selector) {
+    this._hasScrolled = false;
+    this._scrollTimeout = false;
+    this._windowHasResized = false;
+    this._resizeTimeout = false;
+    this._elsLoaded = false;
+    this._initialPositionsSet = false;
+    this._els = [];
+
+    this.CSS_SELECTOR = selector;
+    this.STOP_PADDING = 10;
+  };
+  Sticky.prototype.setMode = function (mode) {
+    _mode = mode;
+  };
+  Sticky.prototype.getWindowDimensions = function () {
+    return {
+      height: $(global).height(),
+      width: $(global).width()
+    };
+  };
+  Sticky.prototype.getWindowPositions = function () {
+    return {
+      scrollTop: $(global).scrollTop()
+    };
+  };
+  // Change state of sticky elements based on their position relative to the window
+  Sticky.prototype.setElementPositions = function () {
+    var self = this,
+        windowDimensions = self.getWindowDimensions(),
+        windowTop = self.getWindowPositions().scrollTop,
+        windowPositions = {
+          'top': windowTop,
+          'bottom':  windowTop + windowDimensions.height
+        };
+
+    var _setElementPosition = function (el) {
+      if (self.viewportIsWideEnough(windowDimensions.width)) {
+
+        if (self.windowNotPastScrolledFrom(windowPositions, self.getScrolledFrom(el))) {
+          self.reset(el);
+        } else { // past the point it sits in the document
+          if (self.windowNotPastScrollingTo(windowPositions, self.getScrollingTo(el))) {
+            self.stick(el);
+            if (el.isStopped()) {
+              self.unstop(el);
+            }
+          } else { // window past scrollingTo position
+            if (!el.isStuck()) {
+              self.stick(el);
+            }
+            self.stop(el);
+          }
+        }
+
+      } else {
+
+        self.reset(el);
+
+      }
+    };
+
+    // clean up any existing styles marking the edges of sticky elements
+    oppositeEdge.unmark(self);
+
+    $.each(self._els, function (i, el) {
+      if (el.canBeStuck()) {
+        _setElementPosition(el);
+      }
+    });
+
+    // add styles to mark the edge of sticky elements opposite to that stuck to the window
+    oppositeEdge.mark(self);
+
+    if (self._initialPositionsSet === false) { self._initialPositionsSet = true; }
+  };
+  // Store all the dimensions for a sticky element to limit DOM queries
+  Sticky.prototype.setElementDimensions = function (el, callback) {
+    var self = this;
+    var $el = el.$fixedEl;
+    var onHeightSet = function () {
+      // if element is shim'ed, pass changes in dimension on to the shim
+      if (el._$shim) {
+        el.updateShim();
+      }
+      if (callback !== undefined) {
+        callback();
+      }
+    };
+
+    this.setElWidth(el);
+    this.setElHeight(el, onHeightSet);
+  };
+  // Reset element to original state in the page
+  Sticky.prototype.reset = function (el) {
+    if (el.isStopped()) {
+      this.unstop(el);
+    }
+    if (el.isStuck()) {
+      this.release(el);
+    }
+  };
+  // Recalculate stored dimensions for all sticky elements
+  Sticky.prototype.recalculate = function () {
+    var self = this;
+    var onSyncComplete = function () {
+      scrollAreas.syncEls(self._els);
+      self.setEvents();
+      if (_mode === 'dialog') {
+        dialog.fitToHeight(self);
+        if (dialog.hasResized) {
+          dialog.adjustForResize(self);
+        }
+      }
+      self.setElementPositions();
+    };
+
+    this.syncWithDOM(onSyncComplete);
+  };
+  Sticky.prototype.setElWidth = function (el) {
+    var $el = el.$fixedEl;
+    var scrollArea = scrollAreas.getAreaByEl(el);
+    var width = $(scrollArea.node).width();
+
+    el.horizontalSpace = width;
+    // if stuck, element won't inherit width from parent so set explicitly
+    if (el._$shim) {
+      $el.width(width);
+    }
+  };
+  Sticky.prototype.setElHeight = function (el, callback) {
+    var self = this;
+    var $el = el.$fixedEl;
+    var $img = $el.find('img');
+    var onload = function () {
+      el.height = $el.outerHeight();
+      // if element has a shim, the shim's offset represents the element's in-page position
+      if (el._$shim) {
+        el.inPageEdgePosition = self.getInPageEdgePosition(el._$shim);
+      } else {
+        el.inPageEdgePosition = self.getInPageEdgePosition($el);
+      }
+      callback();
+    };
+
+    if ((!el.hasLoaded()) && ($img.length > 0)) {
+      var image = new global.Image();
+      image.onload = function () {
+        onload();
+      };
+      image.src = $img.attr('src');
+    } else {
+      onload();
+    }
+  };
+  Sticky.prototype.allElementsLoaded = function (totalEls) {
+    return this._els.length === totalEls;
+  };
+  Sticky.prototype.getElForNode = function (node) {
+    var matches = $.grep(this._els, function (el) { return el.$fixedEl.is(node); });
+
+    return !!matches.length ? matches[0] : false;
+  };
+  Sticky.prototype.add = function (el, setPositions, cb) {
+    var self = this;
+    var $el = $(el);
+    var onDimensionsSet;
+    var elObj = this.getElForNode(el);
+    var exists = !!elObj;
+
+    onDimensionsSet = function () {
+      elObj.hasLoaded(true);
+
+      // guard against adding elements already stored
+      if (!exists) {
+        self._els.push(elObj);
+      }
+
+      if (setPositions) {
+        self.setElementPositions();
+      }
+
+      if (cb !== undefined) {
+        cb();
+      }
+    };
+
+    if (!exists) {
+      elObj = new StickyElement($el, self);
+      scrollAreas.addEl(elObj, self.edge, self.CSS_SELECTOR);
+    }
+
+    self.setElementDimensions(elObj, onDimensionsSet);
+  }; 
+  Sticky.prototype.remove = function (el) {
+    if ($.inArray(el, this._els) !== -1) {
+
+      // reset DOM node to original state
+      this.reset(el);
+
+      // remove sticky element object
+      this._els = $.grep(this._els, function (_el) { return _el !== el; });
+    }
+  };
+  // gets all sticky elements in the DOM and removes any in this._els no longer in attached to it
+  Sticky.prototype.syncWithDOM = function (callback) {
+    var self = this;
+    var $els = $(self.CSS_SELECTOR);
+    var numOfEls = $els.length;
+    var onLoaded;
+
+    onLoaded = function () {
+      if (self._els.length === numOfEls) {
+        self.endOfScrollArea = self.getEndOfScrollArea();
+        if (callback !== undefined) {
+          callback();
+        }
+      }
+    };
+
+    // remove any els no longer in the DOM
+    if (this._els.length) {
+      $.each(this._els, function (i, el) {
+        if (!el.isInPage()) {
+          self.remove(el);
+        }
+      });
+    }
+
+    if (numOfEls) {
+      // reset flag marking page load
+      this._initialPositionsSet = false;
+
+      $els.each(function (i, el) {
+        // delay setting position until all stickys are loaded
+        self.add(el, false, onLoaded);
+      });
+    }
+  };
+  Sticky.prototype.init = function () {
+    this.recalculate();
+  };
+  Sticky.prototype.setEvents = function () {
+    var self = this;
+
+    // flag when scrolling takes place and check (and re-position) sticky elements relative to
+    // window position
+    if (self._scrollTimeout === false) {
+      $(global).scroll(function (e) { self.onScroll(); });
+      self._scrollTimeout = global.setInterval(function (e) { self.checkScroll(); }, 50);
+    }
+
+    // Recalculate all dimensions when the window resizes
+    if (self._resizeTimeout === false) {
+      $(global).resize(function (e) { self.onResize(); });
+      self._resizeTimeout = global.setInterval(function (e) { self.checkResize(); }, 50);
+    }
+  };
+  Sticky.prototype.viewportIsWideEnough = function (windowWidth) {
+    return windowWidth > 768;
+  };
+  Sticky.prototype.onScroll = function () {
+    this._hasScrolled = true;
+  };
+  Sticky.prototype.onResize = function () {
+    this._windowHasResized = true;
+  };
+  Sticky.prototype.checkScroll = function () {
+    var self = this;
+
+    if (self._hasScrolled === true) {
+      self._hasScrolled = false;
+      self.setElementPositions();
+    }
+  };
+  Sticky.prototype.checkResize = function () {
+    var self = this,
+        windowWidth = self.getWindowDimensions().width;
+
+    if (self._windowHasResized === true) {
+      self._windowHasResized = false;
+
+      $.each(self._els, function (i, el) {
+        if (!self.viewportIsWideEnough(windowWidth)) {
+          self.reset(el);
+        } else {
+          self.setElementDimensions(el);
+        }
+      });
+
+      if (self.viewportIsWideEnough(windowWidth)) {
+        if (_mode === 'dialog') {
+          dialog.fitToHeight(self);
+          if (dialog.hasResized) {
+            dialog.adjustForResize(self);
+          }
+        }
+        self.setElementPositions();
+      }
+    }
+  };
+  Sticky.prototype.release = function (el) {
+    if (el.isStuck()) {
+      var $el = el.$fixedEl;
+
+      el.removeStickyClasses(this);
+      $el.css('width', '');
+      // clear styles from any elements stuck while in a dialog mode
+      dialog.releaseEl(el, this);
+      el.removeShim();
+      el.release(this);
+    }
+  };
+
+  // Extension of sticky object to add behaviours specific to sticking to top of window
+  var stickAtTop = new Sticky('.js-stick-at-top-when-scrolling');
+  stickAtTop.edge = 'top';
+  // Store furthest point sticky elements are allowed
+  stickAtTop.getEndOfScrollArea = function () {
+    var footer = $('.js-footer:eq(0)');
+    if (footer.length === 0) {
+      return 0;
+    }
+    return footer.offset().top - this.STOP_PADDING;
+  };
+  // position of the bottom edge when in the page flow
+  stickAtTop.getInPageEdgePosition = function ($el) {
+    return $el.offset().top;
+  };
+  stickAtTop.getScrolledFrom = function (el) {
+    if (_mode === 'dialog') {
+      return dialog.getInPageEdgePosition(this);
+    } else {
+      return el.inPageEdgePosition;
+    }
+  };
+  stickAtTop.getScrollingTo = function (el) {
+    var height = el.height;
+
+    if (_mode === 'dialog') {
+      height = dialog.getHeight(this._els);
+    }
+
+    return this.endOfScrollArea - height;
+  };
+  stickAtTop.getStoppingPosition = function (el) {
+    var offset = 0;
+
+    if (_mode === 'dialog') {
+      offset = dialog.getOffsetFromEnd(el, this);
+    }
+
+    return (this.endOfScrollArea - offset) - el.height;
+  };
+  stickAtTop.windowNotPastScrolledFrom = function (windowPositions, scrolledFrom) {
+    return scrolledFrom > windowPositions.top;
+  };
+  stickAtTop.windowNotPastScrollingTo = function (windowPositions, scrollingTo) {
+    return windowPositions.top < scrollingTo;
+  };
+  stickAtTop.stick = function (el) {
+    if (!el.isStuck()) {
+      var $el = el.$fixedEl;
+      var offset = 0;
+
+      if (_mode === 'dialog') {
+        offset = dialog.getOffsetFromEdge(el, this);
+      }
+
+      el.addShim('before');
+      $el.css({
+        // element will be absolutely positioned so cannot rely on parent element for width
+        'width': $el.width() + 'px',
+        'top': offset + 'px'
+      });
+      el.stick(this);
+    }
+  };
+  stickAtTop.stop = function (el) {
+    if (!el.isStopped()) {
+      el.$fixedEl.css({
+        'position': 'absolute',
+        'top': this.getStoppingPosition(el)
+      });
+      el.stop();
+    }
+  };
+  stickAtTop.unstop = function (el) {
+    var offset = 0;
+
+    if (_mode === 'dialog') {
+      offset = dialog.getOffsetFromEdge(el, this);
+    }
+
+    el.$fixedEl.css({
+      'position': '',
+      'top': offset + 'px'
+    });
+    el.unstop();
+  };
+
+  // Extension of sticky object to add behaviours specific to sticking to bottom of window
+  var stickAtBottom = new Sticky('.js-stick-at-bottom-when-scrolling');
+  stickAtBottom.edge = 'bottom';
+  // Store furthest point sticky elements are allowed
+  stickAtBottom.getEndOfScrollArea = function () {
+    var header = $('.js-header:eq(0)');
+    if (header.length === 0) {
+      return 0;
+    }
+    return (header.offset().top + header.outerHeight()) + this.STOP_PADDING;
+  };
+  // position of the bottom edge when in the page flow
+  stickAtBottom.getInPageEdgePosition = function ($el) {
+    return $el.offset().top + $el.outerHeight();
+  };
+  stickAtBottom.getScrolledFrom = function (el) {
+    if (_mode === 'dialog') {
+      return dialog.getInPageEdgePosition(this);
+    } else {
+      return el.inPageEdgePosition;
+    }
+  };
+  stickAtBottom.getScrollingTo = function (el) {
+    var height = el.height;
+
+    if (_mode === 'dialog') {
+      height = dialog.getHeight(this._els);
+    }
+
+    return this.endOfScrollArea + height;
+  };
+  stickAtBottom.getStoppingPosition = function (el) {
+    var offset = 0;
+
+    if (_mode === 'dialog') {
+      offset = dialog.getOffsetFromEnd(el, this);
+    }
+
+    return this.endOfScrollArea + offset;
+  };
+  stickAtBottom.windowNotPastScrolledFrom = function (windowPositions, scrolledFrom) {
+    return scrolledFrom < windowPositions.bottom;
+  };
+  stickAtBottom.windowNotPastScrollingTo = function (windowPositions, scrollingTo) {
+    return windowPositions.bottom > scrollingTo;
+  };
+  stickAtBottom.stick = function (el) {
+    if (!el.isStuck()) {
+      var $el = el.$fixedEl;
+      var offset = 0;
+
+      if (_mode === 'dialog') {
+        offset = dialog.getOffsetFromEdge(el, this);
+      }
+
+      el.addShim('after');
+      $el.css({
+        // element will be absolutely positioned so cannot rely on parent element for width
+        'width': $el.width() + 'px',
+        'bottom': offset + 'px'
+      });
+      el.stick(this);
+    }
+  };
+  stickAtBottom.stop = function (el) {
+    if (!el.isStopped()) {
+      el.$fixedEl.css({
+        'position': 'absolute',
+        'top': this.getStoppingPosition(el),
+        'bottom': 'auto'
+      });
+      el.stop();
+    }
+  };
+  stickAtBottom.unstop = function (el) {
+    var offset = 0;
+
+    if (_mode === 'dialog') {
+      offset = dialog.getOffsetFromEdge(el, this);
+    }
+
+    el.$fixedEl.css({
+      'position': '',
+      'top': '',
+      'bottom': offset + 'px'
+    });
+    el.unstop();
+  };
+
+  GOVUK.stickAtTopWhenScrolling = stickAtTop;
+  GOVUK.stickAtBottomWhenScrolling = stickAtBottom;
+  global.GOVUK = GOVUK;
+})(window);

--- a/admin/app/assets/stylesheets/components/fullscreen-table.scss
+++ b/admin/app/assets/stylesheets/components/fullscreen-table.scss
@@ -25,7 +25,7 @@
 
     th,
     .table-field-error-label,
-    .table-field-center-aligned {
+    .table-field-left-aligned {
       white-space: nowrap;
     }
 
@@ -62,7 +62,7 @@
       display: none;
     }
 
-    .table-field-center-aligned {
+    .table-field-left-aligned {
       position: relative;
       z-index: 150;
       background: $white;
@@ -100,7 +100,7 @@
       visibility: hidden;
     }
 
-    .table-field-center-aligned {
+    .table-field-left-aligned {
       width: 0;
       position: relative;
       z-index: 100;

--- a/admin/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
+++ b/admin/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
@@ -1,23 +1,24 @@
 // CSS adapted from
 // https://github.com/alphagov/govuk_frontend_toolkit/blob/d9489a987086471fe30b4b925a81c12cd198c91d/docs/javascript.md#stick-at-top-when-scrolling
 
-.js-stick-at-top-when-scrolling {
+$sticky-padding: $gutter * 2 / 3;
 
+.js-stick-at-top-when-scrolling,
+.js-stick-at-bottom-when-scrolling {
   overflow: hidden;
   margin-left: -$gutter-half;
-  margin-top: -10px;
-  margin-bottom: 5px;
   padding: 10px 0 0 $gutter-half;
   position: relative;
-  top: 5px;
-  transition: top 0.1s ease-out, box-shadow 1s ease-in-out;
 
   .form-group {
     margin-bottom: 20px;
+
+    legend {
+      outline: none;
+    }
   }
 
   .back-to-top-link {
-
     position: absolute;
     top: $gutter;
     right: $gutter-half;
@@ -27,28 +28,89 @@
     @include ie-lte(8) {
       display: none;
     }
-
   }
-
 }
 
-.content-fixed {
+.js-stick-at-top-when-scrolling {
+  margin-top: -10px;
+  margin-bottom: 5px;
+  top: 5px;
+  transition: top 0.1s ease-out, box-shadow 1s ease-in-out;
+}
 
+.js-stick-at-bottom-when-scrolling {
+  transition: bottom 0.1s ease-out, box-shadow 1s ease-in-out;
+  padding: $sticky-padding 0 $sticky-padding $gutter-half;
+  margin-top: -$sticky-padding;
+
+  & + .js-stick-at-bottom-when-scrolling {
+    margin-top: ($sticky-padding * 2) * -1;
+  }
+
+  .page-footer {
+    margin-bottom: 0;
+    min-height: 50px;
+  }
+
+  .page-footer-delete-link-without-button {
+    margin-top: 10px;
+  }
+
+  .notification-status {
+    margin: 0;
+  }
+
+  .button-secondary {
+    margin-right: $gutter-half;
+  }
+}
+
+.content-fixed,
+.content-fixed-onload {
   position: fixed;
-  top: 0;
   background: $white;
   z-index: 100;
-  margin-top: 0;
   padding-right: $gutter-half;
-  border-bottom: 1px solid $border-colour;
-  box-shadow: 0 2px 0 0 rgba($border-colour, 0.2);
-  transition: background 0.6s ease-in-out, margin-top 0.4s ease-out;
+  margin-top: 0;
 
   .back-to-top-link {
     opacity: 1;
     transition: opacity 0.6s ease-in-out;
   }
+}
 
+.js-stick-at-top-when-scrolling.content-fixed,
+.js-stick-at-top-when-scrolling.content-fixed-onload {
+  top: 0;
+  margin-top: 0;
+}
+
+.js-stick-at-top-when-scrolling.content-fixed__top {
+  border-bottom: 1px solid $border-colour;
+  box-shadow: 0 2px 0 0 rgba($border-colour, 0.2);
+}
+
+.js-stick-at-top-when-scrolling.content-fixed {
+  transition: background 0.6s ease-in-out, margin-top 0.4s ease-out;
+}
+
+.js-stick-at-bottom-when-scrolling.content-fixed,
+.js-stick-at-bottom-when-scrolling.content-fixed-onload {
+  top: auto; // cancel `top: 0;` inherited from govuk-template
+  bottom: 0;
+}
+
+.js-stick-at-bottom-when-scrolling.content-fixed__bottom {
+  border-top: 1px solid $border-colour;
+  box-shadow: 0 -2px 0 0 rgba($border-colour, 0.2);
+}
+
+.js-stick-at-bottom-when-scrolling.content-fixed {
+  transition: background 0.6s ease-in-out;
+}
+
+.js-stick-at-bottom-when-scrolling-loaded.content-fixed-onload {
+  transition: none;
 }
 
 .shim {

--- a/admin/app/notify_client/job_api_client.py
+++ b/admin/app/notify_client/job_api_client.py
@@ -60,6 +60,9 @@ class JobApiClient(NotifyAdminAPIClient):
 
         return jobs
 
+    def has_jobs(self, service_id):
+        return bool(self.get_jobs(service_id)['data'])
+
     def create_job(self, job_id, service_id, template_id, original_file_name, notification_count, scheduled_for=None):
         data = {
             "id": job_id,

--- a/admin/app/templates/components/page-footer.html
+++ b/admin/app/templates/components/page-footer.html
@@ -1,5 +1,7 @@
 {% macro page_footer(
   button_text=None,
+  button_name=None,
+  button_value=None,
   destructive=False,
   back_link=False,
   back_link_text="Back",
@@ -11,7 +13,14 @@
   <div class="page-footer">
     {% if button_text %}
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-      <button type="submit" class="button{% if destructive %}-destructive{% endif %}">{{ button_text }}</button>
+      <button
+        type="submit"
+        class="button{% if destructive %}-destructive{% endif %}"
+        {% if button_name %}name="{{ button_name }}"{% endif %}
+        {% if button_value %}value="{{ button_value }}"{% endif %}
+      >
+        {{- button_text -}}
+      </button>
     {% endif %}
     {% if back_link %}
       <a class="page-footer-secondary-link" href="{{ back_link }}">← {{ back_link_text }}</a>
@@ -24,5 +33,11 @@
     {% if secondary_link and secondary_link_text %}
       <a class="page-footer-secondary-link" href="{{ secondary_link }}">{{ secondary_link_text }}</a>
     {% endif %}
+  </div>
+{% endmacro %}
+
+{% macro sticky_page_footer(button_text=None) %}
+  <div class="js-stick-at-bottom-when-scrolling">
+    {{ page_footer(button_text) }}
   </div>
 {% endmacro %}

--- a/admin/app/templates/components/page-header.html
+++ b/admin/app/templates/components/page-header.html
@@ -1,12 +1,12 @@
 {% macro page_header(
-    h1,
-    back_link=None
-  ) %}
-  
-    {% if back_link %}
-        <a  href="{{ back_link }}">Back</a>
-    {% endif %}
-  
-    <h1 class="heading-large">{{ h1 }}</h1>
-  
-  {% endmacro %}
+  h1,
+  back_link=None
+) %}
+
+  {% if back_link %}
+    <a  href="{{ back_link }}">Back</a>
+  {% endif %}
+
+  <h1 class="heading-large">{{ h1 }}</h1>
+
+{% endmacro %}

--- a/admin/app/templates/components/page-header.html
+++ b/admin/app/templates/components/page-header.html
@@ -4,9 +4,16 @@
 ) %}
 
   {% if back_link %}
-    <a  href="{{ back_link }}">Back</a>
+    {{ govau_back_link(back_link) }}
   {% endif %}
 
   <h1 class="heading-large">{{ h1 }}</h1>
+
+{% endmacro %}
+
+
+{% macro govau_back_link(back_link) %}
+
+  <a href="{{ back_link }}">Back</a>
 
 {% endmacro %}

--- a/admin/app/templates/components/table.html
+++ b/admin/app/templates/components/table.html
@@ -64,7 +64,7 @@
 
 {% macro field(align='left', status='', border=True) -%}
 
-    {% set field_alignment = 'table-field-right-aligned' if align == 'right' else 'table-field-center-aligned' %}
+    {% set field_alignment = 'table-field-right-aligned' if align == 'right' else 'table-field-left-aligned' %}
     {% set border = '' if border else 'table-field-noborder' %}
 
     <td class="{{ [field_alignment, border]|join(' ') }}">

--- a/admin/app/templates/views/edit-email-template.html
+++ b/admin/app/templates/views/edit-email-template.html
@@ -1,7 +1,9 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
-{% from "components/page-footer.html" import page_footer %}
+{% from "components/page-header.html" import page_header %}
+{% from "components/page-footer.html" import sticky_page_footer %}
 {% from "components/radios.html" import radios %}
+{% from "components/form.html" import form_wrapper %}
 
 {% block service_page_title %}
   {{ heading_action }} email template
@@ -9,11 +11,11 @@
 
 {% block maincolumn_content %}
 
-    <h1 class="heading-large">
-      {{ heading_action }} email template
-    </h1>
+    {{ page_header(
+      '{} email template'.format(heading_action)
+    ) }}
 
-    <form method="post">
+    {% call form_wrapper() %}
       <div class="grid-row">
         <div class="column-five-sixths">
           {{ textbox(form.name, width='1-1', hint='Your recipients won’t see this', rows=10) }}
@@ -22,7 +24,7 @@
           {% if current_user.platform_admin %}
              {{ radios(form.process_type) }}
           {% endif %}
-          {{ page_footer(
+          {{ sticky_page_footer(
             'Save'
           ) }}
         </div>
@@ -33,6 +35,6 @@
           {% include "partials/templates/guidance-links.html" %}
         </aside>
       </div>
-    </form>
+    {% endcall %}
 
 {% endblock %}

--- a/admin/app/templates/views/edit-letter-template.html
+++ b/admin/app/templates/views/edit-letter-template.html
@@ -1,6 +1,9 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
-{% from "components/page-footer.html" import page_footer %}
+{% from "components/page-header.html" import page_header %}
+{% from "components/page-footer.html" import sticky_page_footer %}
+{% from "components/radios.html" import radios %}
+{% from "components/form.html" import form_wrapper %}
 
 {% block service_page_title %}
   {{ heading_action }} letter template
@@ -8,17 +11,17 @@
 
 {% block maincolumn_content %}
 
-    <h1 class="heading-large">
-      {{ heading_action }} letter template
-    </h1>
+    {{ page_header(
+      '{} letter template'.format(heading_action)
+    ) }}
 
-    <form method="post">
+    {% call form_wrapper() %}
       <div class="grid-row">
         <div class="column-five-sixths">
           {{ textbox(form.name, width='1-1', hint='Your recipients won’t see this', rows=10) }}
           {{ textbox(form.subject, width='1-1', highlight_tags=True, rows=2) }}
           {{ textbox(form.template_content, highlight_tags=True, width='1-1', rows=8) }}
-          {{ page_footer(
+          {{ sticky_page_footer(
             'Save'
           ) }}
         </div>
@@ -27,6 +30,6 @@
           {% include "partials/templates/guidance-personalisation.html" %}
         </aside>
       </div>
-    </form>
+    {% endcall %}
 
 {% endblock %}

--- a/admin/app/templates/views/edit-sms-template.html
+++ b/admin/app/templates/views/edit-sms-template.html
@@ -1,7 +1,9 @@
 {% extends "withnav_template.html" %}
 {% from "components/textbox.html" import textbox %}
-{% from "components/page-footer.html" import page_footer %}
+{% from "components/page-header.html" import page_header %}
+{% from "components/page-footer.html" import sticky_page_footer %}
 {% from "components/radios.html" import radios %}
+{% from "components/form.html" import form_wrapper %}
 
 {% block service_page_title %}
   {{ heading_action }} text message template
@@ -9,11 +11,11 @@
 
 {% block maincolumn_content %}
 
-    <h1 class="heading-large">
-      {{ heading_action }} text message template
-    </h1>
+    {{ page_header(
+      '{} text message template'.format(heading_action)
+    ) }}
 
-    <form method="post">
+    {% call form_wrapper() %}
       <div class="grid-row">
         <div class="column-two-thirds">
           {{ textbox(form.name, width='1-1', hint='Your recipients won’t see this') }}
@@ -23,7 +25,7 @@
           {% if current_user.platform_admin %}
             {{ radios(form.process_type) }}
           {% endif %}
-          {{ page_footer(
+          {{ sticky_page_footer(
             'Save'
           ) }}
         </div>
@@ -34,7 +36,7 @@
           {% include "partials/templates/guidance-character-count.html" %}
         </aside>
       </div>
-    </form>
+    {% endcall %}
 
 
 {% endblock %}

--- a/admin/app/templates/views/notifications/check.html
+++ b/admin/app/templates/views/notifications/check.html
@@ -1,13 +1,15 @@
 {% extends "withnav_template.html" %}
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/message-count-label.html" import message_count_label %}
+{% from "components/page-header.html" import govau_back_link, page_header %}
 
 {% block service_page_title %}
-  {{ "Error" if error else "Preview of {}".format(template.name) }}
+  {{ "Error" if error else "Preview of ‘{}’".format(template.name) }}
 {% endblock %}
 
 {% block maincolumn_content %}
   {% if error == 'not-allowed-to-send-to' %}
+    {{ govau_back_link(back_link) }}
     <div class="bottom-gutter">
       {% call banner_wrapper(type='dangerous') %}
         {% with
@@ -21,6 +23,7 @@
       {% endcall %}
     </div>
   {% elif error == 'too-many-messages' %}
+    {{ govau_back_link(back_link) }}
     <div class="bottom-gutter">
       {% call banner_wrapper(type='dangerous') %}
         {% include "partials/check/too-many-messages.html" %}
@@ -28,20 +31,22 @@
     </div>
   {% elif error == 'message-too-long' %}
     {# the only row_errors we can get when sending one off messages is that the message is too long #}
+    {{ govau_back_link(back_link) }}
     <div class="bottom-gutter">
       {% call banner_wrapper(type='dangerous') %}
         {% include "partials/check/message-too-long.html" %}
       {% endcall %}
     </div>
   {% else %}
-    <h1 class="heading-large">
-      Preview of {{ template.name }}
-    </h1>
+    {{ page_header(
+      'Preview of ‘{}’'.format(template.name),
+      back_link=back_link
+    ) }}
   {% endif %}
 
   {{ template|string }}
 
-  <div class="bottom-gutter-3-2">
+  <div class="js-stick-at-bottom-when-scrolling">
     <form method="post" enctype="multipart/form-data" action="{{url_for(
         'main.send_notification',
         service_id=current_service.id,
@@ -50,13 +55,8 @@
       )}}" class='page-footer'>
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
       {% if not error %}
-        {% if template.template_type != 'letter' or not request.args.from_test %}
         <button type="submit" class="button">Send 1 {{ message_count_label(1, template.template_type, suffix='') }}</button>
-        {% else %}
-          <a href="{{ url_for('main.check_messages_preview', service_id=current_service.id, template_id=template.id, upload_id=upload_id, filetype='pdf') }}" download class="button">Download as a printable PDF</a>
-        {% endif %}
       {% endif %}
-      <a href="{{ back_link }}" class="page-footer-secondary-link">Back</a>
     </form>
   </div>
 

--- a/admin/app/templates/views/service-settings/set-email-branding.html
+++ b/admin/app/templates/views/service-settings/set-email-branding.html
@@ -1,6 +1,8 @@
 {% extends "withnav_template.html" %}
 {% from "components/radios.html" import radios, branding_radios %}
-{% from "components/page-footer.html" import page_footer %}
+{% from "components/page-header.html" import page_header %}
+{% from "components/page-footer.html" import page_footer, sticky_page_footer %}
+{% from "components/form.html" import form_wrapper %}
 
 {% block service_page_title %}
   Set email branding
@@ -8,19 +10,22 @@
 
 {% block maincolumn_content %}
 
-  <h1 class="heading-large">Set email branding</h1>
-  <div class="grid-row">
-    <div class="column-three-quarters">
-      <form method="post">
+  {{ page_header(
+    'Set email branding',
+    back_link=url_for('.service_settings', service_id=current_service.id)
+  ) }}
+  {% call form_wrapper() %}
+    <div class="grid-row">
+      <div class="column-full preview-pane">
+      </div>
+    </div>
+    <div class="grid-row">
+      <div class="column-full">
         {{ radios(form.branding_type) }}
         {{ branding_radios(form.branding_style, branding_dict=branding_dict) }}
-        {{ page_footer(
-          'Save',
-          back_link=url_for('.service_settings', service_id=current_service.id),
-          back_link_text='Back to settings'
-        ) }}
-      </form>
+      </div>
     </div>
-  </div>
+    {{ sticky_page_footer('Save') }}
+  {% endcall %}
 
 {% endblock %}

--- a/admin/gulpfile.babel.js
+++ b/admin/gulpfile.babel.js
@@ -68,8 +68,7 @@ gulp.task("javascripts", () =>
     .src([
       paths.src + "javascripts/sentry.js",
       paths.toolkit + "javascripts/govuk/modules.js",
-      paths.toolkit + "javascripts/govuk/stop-scrolling-at-footer.js",
-      paths.toolkit + "javascripts/govuk/stick-at-top-when-scrolling.js",
+      paths.src + "javascripts/stick-to-window-when-scrolling.js",
       paths.src + "javascripts/detailsPolyfill.js",
       paths.src + "javascripts/apiKey.js",
       paths.src + "javascripts/autofocus.js",

--- a/admin/tests/app/main/views/test_dashboard.py
+++ b/admin/tests/app/main/views/test_dashboard.py
@@ -514,7 +514,7 @@ def test_monthly_shows_letters_in_breakdown(
         service_id=service_one['id']
     )
 
-    columns = page.select('.table-field-center-aligned .big-number-label')
+    columns = page.select('.table-field-left-aligned .big-number-label')
 
     assert normalize_spaces(columns[0].text) == 'emails'
     assert normalize_spaces(columns[1].text) == 'text messages'

--- a/admin/tests/app/main/views/test_send.py
+++ b/admin/tests/app/main/views/test_send.py
@@ -606,10 +606,10 @@ def test_upload_valid_csv_shows_preview_and_table(
 
     for row_index, row in enumerate([
         (
-            '<td class="table-field-center-aligned "> <div class=""> 0470900001 </div> </td>',
-            '<td class="table-field-center-aligned "> <div class=""> A </div> </td>',
+            '<td class="table-field-left-aligned "> <div class=""> 0470900001 </div> </td>',
+            '<td class="table-field-left-aligned "> <div class=""> A </div> </td>',
             (
-                '<td class="table-field-center-aligned "> '
+                '<td class="table-field-left-aligned "> '
                 '<div class="table-field-status-default"> '
                 '<ul class="list list-bullet"> '
                 '<li>foo</li> <li>foo</li> <li>foo</li> '
@@ -619,10 +619,10 @@ def test_upload_valid_csv_shows_preview_and_table(
             )
         ),
         (
-            '<td class="table-field-center-aligned "> <div class=""> 0470900002 </div> </td>',
-            '<td class="table-field-center-aligned "> <div class=""> B </div> </td>',
+            '<td class="table-field-left-aligned "> <div class=""> 0470900002 </div> </td>',
+            '<td class="table-field-left-aligned "> <div class=""> B </div> </td>',
             (
-                '<td class="table-field-center-aligned "> '
+                '<td class="table-field-left-aligned "> '
                 '<div class="table-field-status-default"> '
                 '<ul class="list list-bullet"> '
                 '<li>foo</li> <li>foo</li> <li>foo</li> '
@@ -632,10 +632,10 @@ def test_upload_valid_csv_shows_preview_and_table(
             )
         ),
         (
-            '<td class="table-field-center-aligned "> <div class=""> 0470900003 </div> </td>',
-            '<td class="table-field-center-aligned "> <div class=""> C </div> </td>',
+            '<td class="table-field-left-aligned "> <div class=""> 0470900003 </div> </td>',
+            '<td class="table-field-left-aligned "> <div class=""> C </div> </td>',
             (
-                '<td class="table-field-center-aligned "> '
+                '<td class="table-field-left-aligned "> '
                 '<div class="table-field-status-default"> '
                 '<ul class="list list-bullet"> '
                 '<li>foo</li> <li>foo</li> '
@@ -929,6 +929,33 @@ def test_send_one_off_has_skip_link(
         )
     else:
         assert not skip_links
+
+
+@pytest.mark.parametrize('template_mock, expected_sticky', [
+    (mock_get_service_template, False),
+    (mock_get_service_email_template, True),
+    (mock_get_service_letter_template, True),
+])
+def test_send_one_off_has_sticky_header_for_email_and_letter(
+    mocker,
+    client_request,
+    fake_uuid,
+    mock_has_no_jobs,
+    template_mock,
+    expected_sticky,
+):
+    template_mock(mocker)
+    mocker.patch('app.main.views.send.get_page_count_for_letter', return_value=9)
+
+    page = client_request.get(
+        'main.send_one_off_step',
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        step_index=0,
+        _follow_redirects=True,
+    )
+
+    assert bool(page.select('.js-stick-at-top-when-scrolling')) == expected_sticky
 
 
 def test_skip_link_will_not_show_on_sms_one_off_if_service_has_no_mobile_number(

--- a/admin/tests/conftest.py
+++ b/admin/tests/conftest.py
@@ -49,7 +49,7 @@ def app_(request):
 @pytest.fixture(scope='function')
 def service_one(api_user_active):
     return service_json(SERVICE_ONE_ID, 'service one', [api_user_active.id])
-    
+
 @pytest.fixture(scope='function')
 def service_two(api_user_active):
     return service_json(SERVICE_TWO_ID, 'service two', [api_user_active.id])
@@ -1723,6 +1723,16 @@ def mock_get_job_in_progress(mocker, api_user_active):
         )}
 
     return mocker.patch('app.job_api_client.get_job', side_effect=_get_job)
+
+
+@pytest.fixture(scope='function')
+def mock_has_jobs(mocker):
+    mocker.patch('app.job_api_client.has_jobs', return_value=True)
+
+
+@pytest.fixture(scope='function')
+def mock_has_no_jobs(mocker):
+    mocker.patch('app.job_api_client.has_jobs', return_value=False)
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
Applied to:

- email and SMS template pages
- send one-off email/SMS page
- set service email branding page

There are many other pages we can introduce sticky footers/buttons such
as API keys and email reply addresses.