### PR TITLE
admin: fix wrong @digital.gov.au from address

### DIFF
--- a/admin/app/templates/views/service-settings/email_reply_to.html
+++ b/admin/app/templates/views/service-settings/email_reply_to.html
@@ -49,7 +49,7 @@
     <div class="column-five-sixths">
       <p>
         Your emails will be sent from
-        {{ current_service.email_from }}@digital.gov.au
+        {{ current_service.email_from }}@notify.gov.au
       </p>
       <p>
         This is so they have the best chance of being delivered.


### PR DESCRIPTION
This was a missed change from the move to SES and the change to send
from @notify.gov.au.