### PR TITLE
Fix message limit on services (25,000->250,000)

### DIFF
--- a/admin/app/notify_client/service_api_client.py
+++ b/admin/app/notify_client/service_api_client.py
@@ -130,7 +130,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
     def update_status(self, service_id, live):
         return self.update_service(
             service_id,
-            message_limit=25000 if live else 50,
+            message_limit=250000 if live else 50,
             restricted=(not live),
             go_live_at=str(datetime.utcnow()) if live else None
         )

--- a/admin/tests/app/main/views/test_service_settings.py
+++ b/admin/tests/app/main/views/test_service_settings.py
@@ -340,7 +340,7 @@ def test_switch_service_to_live(
         service_id=service_one['id'], _external=True)
     mock_update_service.assert_called_with(
         service_one['id'],
-        message_limit=25000,
+        message_limit=250000,
         restricted=False
     )
 

--- a/api/migrations/versions/0225_fix_service_message_limit.py
+++ b/api/migrations/versions/0225_fix_service_message_limit.py
@@ -1,0 +1,29 @@
+"""
+
+Revision ID: 0225
+Revises: 0224
+Create Date: 2019-07-05 14:44:14.288849
+
+"""
+from alembic import op
+
+
+revision = '0225'
+down_revision = '0224'
+
+# This is the date the commit was made that incorrectly set the message limit to
+# 25,000 when it should have remained at 250,000.
+# By using this date in the where clause below, we only update services that
+# were created after this commit was made.
+# See https://github.com/govau/notify/commit/b29f135dca87aec32daed0a2b41243b6d0bd89be#diff-9ea0fa34caf8fb2b9fbb389ea322bee4L231
+commit_date = '2019-02-05T04:26:25Z'
+
+
+def upgrade():
+    op.execute("update services set message_limit = 250000 where message_limit = 25000 and restricted = false and created_at > '{}'".format(commit_date))
+    op.execute("update services_history set message_limit = 250000 where message_limit = 25000 and restricted and created_at > '{}'".format(commit_date))
+
+
+def downgrade():
+    op.execute("update services_history set message_limit = 25000 where message_limit = 250000 and restricted = false and created_at > '{}'".format(commit_date))
+    op.execute("update services set message_limit = 25000 where message_limit = 250000 and restricted = false and created_at > '{}'".format(commit_date))


### PR DESCRIPTION
The limit was incorrectly set to 25,000 during the change that set the
SMS message fragment limit to 25,000.

See https://github.com/govau/notify/commit/b29f135dca87aec32daed0a2b41243b6d0bd89be#diff-9ea0fa34caf8fb2b9fbb389ea322bee4L231