### PR TITLE
admin: initialise clients outside the app

### DIFF
--- a/admin/app/asset_fingerprinter.py
+++ b/admin/app/asset_fingerprinter.py
@@ -36,7 +36,7 @@ class AssetFingerprinter(object):
         return self._cache[asset_path]
 
     def get_asset_fingerprint(self, asset_file_path):
-        return hashlib.md5( # nosec
+        return hashlib.md5(  # nosec
             self.get_asset_file_contents(asset_file_path).encode('utf-8')
         ).hexdigest()
 
@@ -44,3 +44,6 @@ class AssetFingerprinter(object):
         with codecs.open(asset_file_path, encoding='utf-8') as asset_file:
             contents = asset_file.read()
         return contents
+
+
+asset_fingerprinter = AssetFingerprinter()

--- a/admin/app/notify_client/api_key_api_client.py
+++ b/admin/app/notify_client/api_key_api_client.py
@@ -30,3 +30,6 @@ class ApiKeyApiClient(NotifyAdminAPIClient):
         return self.post(
             url='/service/{0}/api-key/revoke/{1}'.format(service_id, key_id),
             data=data)
+
+
+api_key_api_client = ApiKeyApiClient()

--- a/admin/app/notify_client/billing_api_client.py
+++ b/admin/app/notify_client/billing_api_client.py
@@ -41,3 +41,6 @@ class BillingAPIClient(NotifyAdminAPIClient):
             url='/service/{0}/billing/free-sms-fragment-limit'.format(service_id),
             data=data
         )
+
+
+billing_api_client = BillingAPIClient()

--- a/admin/app/notify_client/email_branding_client.py
+++ b/admin/app/notify_client/email_branding_client.py
@@ -30,3 +30,6 @@ class EmailBrandingClient(NotifyAdminAPIClient):
             "colour": colour
         }
         return self.post(url="/email-branding/{}".format(branding_id), data=data)
+
+
+email_branding_client = EmailBrandingClient()

--- a/admin/app/notify_client/events_api_client.py
+++ b/admin/app/notify_client/events_api_client.py
@@ -12,3 +12,6 @@ class EventsApiClient(NotifyAdminAPIClient):
         }
         resp = self.post(url='/events', data=data)
         return resp['data']
+
+
+events_api_client = EventsApiClient()

--- a/admin/app/notify_client/inbound_number_client.py
+++ b/admin/app/notify_client/inbound_number_client.py
@@ -14,3 +14,6 @@ class InboundNumberClient(NotifyAdminAPIClient):
 
     def get_inbound_sms_number_for_service(self, service_id):
         return self.get('/inbound-number/service/{}'.format(service_id))
+
+
+inbound_number_client = InboundNumberClient()

--- a/admin/app/notify_client/invite_api_client.py
+++ b/admin/app/notify_client/invite_api_client.py
@@ -55,3 +55,6 @@ class InviteApiClient(NotifyAdminAPIClient):
             invited_user = InvitedUser(**invite)
             invited_users.append(invited_user)
         return invited_users
+
+
+invite_api_client = InviteApiClient()

--- a/admin/app/notify_client/job_api_client.py
+++ b/admin/app/notify_client/job_api_client.py
@@ -96,3 +96,6 @@ class JobApiClient(NotifyAdminAPIClient):
         job['data']['notifications_requested'] = stats['requested']
 
         return job
+
+
+job_api_client = JobApiClient()

--- a/admin/app/notify_client/letter_jobs_client.py
+++ b/admin/app/notify_client/letter_jobs_client.py
@@ -14,3 +14,6 @@ class LetterJobsClient(NotifyAdminAPIClient):
             url='/send-letter-jobs',
             data={"job_ids": job_ids}
         )['data']
+
+
+letter_jobs_client = LetterJobsClient()

--- a/admin/app/notify_client/notification_api_client.py
+++ b/admin/app/notify_client/notification_api_client.py
@@ -84,3 +84,6 @@ class NotificationApiClient(NotifyAdminAPIClient):
         )
 
         return self.get(url=get_url)
+
+
+notification_api_client = NotificationApiClient()

--- a/admin/app/notify_client/org_invite_api_client.py
+++ b/admin/app/notify_client/org_invite_api_client.py
@@ -49,3 +49,6 @@ class OrgInviteApiClient(NotifyAdminAPIClient):
             invited_user = InvitedOrgUser(**invite)
             invited_users.append(invited_user)
         return invited_users
+
+
+org_invite_api_client = OrgInviteApiClient()

--- a/admin/app/notify_client/organisations_api_client.py
+++ b/admin/app/notify_client/organisations_api_client.py
@@ -51,3 +51,6 @@ class OrganisationsClient(NotifyAdminAPIClient):
             url="/organisations/unique",
             params={"org_id": org_id, "name": name}
         )["result"]
+
+
+organisations_client = OrganisationsClient()

--- a/admin/app/notify_client/provider_client.py
+++ b/admin/app/notify_client/provider_client.py
@@ -27,3 +27,6 @@ class ProviderClient(NotifyAdminAPIClient):
         }
         data = _attach_current_user(data)
         return self.post(url='/provider-details/{}'.format(provider_id), data=data)
+
+
+provider_client = ProviderClient()

--- a/admin/app/notify_client/service_api_client.py
+++ b/admin/app/notify_client/service_api_client.py
@@ -460,3 +460,6 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             "updated_by_id": user_id
         }
         return self.post("/service/{}/delivery-receipt-api".format(service_id), data)
+
+
+service_api_client = ServiceAPIClient()

--- a/admin/app/notify_client/status_api_client.py
+++ b/admin/app/notify_client/status_api_client.py
@@ -8,3 +8,6 @@ class StatusApiClient(NotifyAdminAPIClient):
 
     def get_status(self, *params):
         return self.get(url='/_status', *params)
+
+
+status_api_client = StatusApiClient()

--- a/admin/app/notify_client/support_api_client.py
+++ b/admin/app/notify_client/support_api_client.py
@@ -1,9 +1,13 @@
 
 from app.notify_client import NotifyAdminAPIClient
 
+
 class SupportApiClient(NotifyAdminAPIClient):
     def __init__(self):
         super().__init__("a" * 73, "b")
 
     def post_support_ticket(self, data):
         return self.post('/support', data)
+
+
+support_api_client = SupportApiClient()

--- a/admin/app/notify_client/template_statistics_api_client.py
+++ b/admin/app/notify_client/template_statistics_api_client.py
@@ -26,3 +26,6 @@ class TemplateStatisticsApiClient(NotifyAdminAPIClient):
         return self.get(
             url='/service/{}/template-statistics/{}'.format(service_id, template_id)
         )['data']
+
+
+template_statistics_client = TemplateStatisticsApiClient()

--- a/admin/app/notify_client/user_api_client.py
+++ b/admin/app/notify_client/user_api_client.py
@@ -194,3 +194,6 @@ class UserApiClient(NotifyAdminAPIClient):
     def get_organisations_and_services_for_user(self, user):
         endpoint = '/user/{}/organisations-and-services'.format(user.id)
         return self.get(endpoint)
+
+
+user_api_client = UserApiClient()


### PR DESCRIPTION
This avoids the annoying problem where you can't import a client unless
the app has already been initialised.

See https://github.com/alphagov/notifications-admin/commit/9e798506c5aeb2749b8f766bdba168a48e661892