### PR TITLE
api: add DB migrations

### DIFF
--- a/api/migrations/versions/0227_invited_users_folder_permissions.py
+++ b/api/migrations/versions/0227_invited_users_folder_permissions.py
@@ -1,0 +1,22 @@
+"""
+
+Revision ID: 0227
+Revises: 0226
+Create Date: 2019-07-09 15:39:25.569097
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = '0227'
+down_revision = '0226'
+
+
+def upgrade():
+    op.add_column('invited_users', sa.Column('folder_permissions', postgresql.JSONB(none_as_null=True, astext_type=sa.Text()), nullable=True))
+
+
+def downgrade():
+    op.drop_column('invited_users', 'folder_permissions')

--- a/api/migrations/versions/0228_add_letter_branding_table.py
+++ b/api/migrations/versions/0228_add_letter_branding_table.py
@@ -1,0 +1,39 @@
+"""
+
+Revision ID: 0228
+Revises: 0227
+Create Date: 2019-07-09 19:44:36.508754
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = '0228'
+down_revision = '0227'
+
+
+def upgrade():
+    op.create_table('letter_branding',
+                    sa.Column('id', postgresql.UUID(as_uuid=True), nullable=False),
+                    sa.Column('name', sa.String(length=255), nullable=False),
+                    sa.Column('filename', sa.String(length=255), nullable=False),
+                    sa.Column('domain', sa.Text(), nullable=True),
+                    sa.PrimaryKeyConstraint('id'),
+                    sa.UniqueConstraint('domain'),
+                    sa.UniqueConstraint('filename'),
+                    sa.UniqueConstraint('name')
+                    )
+    op.create_table('service_letter_branding',
+                    sa.Column('service_id', postgresql.UUID(as_uuid=True), nullable=False),
+                    sa.Column('letter_branding_id', postgresql.UUID(as_uuid=True), nullable=False),
+                    sa.ForeignKeyConstraint(['letter_branding_id'], ['letter_branding.id'], ),
+                    sa.ForeignKeyConstraint(['service_id'], ['services.id'], ),
+                    sa.PrimaryKeyConstraint('service_id')
+                    )
+
+
+def downgrade():
+    op.drop_table('service_letter_branding')
+    op.drop_table('letter_branding')

--- a/api/migrations/versions/0229_organisation_fields_and_domain.py
+++ b/api/migrations/versions/0229_organisation_fields_and_domain.py
@@ -1,0 +1,66 @@
+"""
+
+Revision ID: 0229
+Revises: 0228
+Create Date: 2019-07-09 19:46:21.988377
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = '0229'
+down_revision = '0228'
+
+
+def upgrade():
+    op.create_table(
+        'domain',
+        sa.Column('domain', sa.String(length=255), nullable=False),
+        sa.Column('organisation_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(['organisation_id'], ['organisation.id'], ),
+        sa.PrimaryKeyConstraint('domain')
+    )
+
+    op.add_column('organisation', sa.Column('email_branding_id', postgresql.UUID(as_uuid=True), nullable=True))
+    op.create_foreign_key('fk_organisation_email_branding_id', 'organisation', 'email_branding', ['email_branding_id'], ['id'])
+
+    op.add_column('organisation', sa.Column('letter_branding_id', postgresql.UUID(as_uuid=True), nullable=True))
+    op.create_foreign_key('fk_organisation_letter_branding_id', 'organisation', 'letter_branding', ['letter_branding_id'], ['id'])
+
+    op.add_column('organisation', sa.Column('agreement_signed', sa.Boolean(), nullable=True))
+    op.add_column('organisation', sa.Column('agreement_signed_at', sa.DateTime(), nullable=True))
+    op.add_column('organisation', sa.Column('agreement_signed_by_id', postgresql.UUID(as_uuid=True), nullable=True))
+    op.add_column('organisation', sa.Column('agreement_signed_version', sa.Float(), nullable=True))
+    op.add_column('organisation', sa.Column('crown', sa.Boolean(), nullable=True))
+    op.add_column('organisation', sa.Column('organisation_type', sa.String(length=255), nullable=True))
+    op.create_foreign_key('fk_organisation_agreement_user_id', 'organisation', 'users', ['agreement_signed_by_id'], ['id'])
+
+    op.add_column('organisation', sa.Column('request_to_go_live_notes', sa.Text(), nullable=True))
+
+    op.add_column('organisation', sa.Column('agreement_signed_on_behalf_of_email_address', sa.String(length=255), nullable=True))
+    op.add_column('organisation', sa.Column('agreement_signed_on_behalf_of_name', sa.String(length=255), nullable=True))
+
+
+def downgrade():
+    op.drop_column('organisation', 'agreement_signed_on_behalf_of_name')
+    op.drop_column('organisation', 'agreement_signed_on_behalf_of_email_address')
+
+    op.drop_column('organisation', 'request_to_go_live_notes')
+
+    op.drop_constraint('fk_organisation_agreement_user_id', 'organisation', type_='foreignkey')
+    op.drop_column('organisation', 'organisation_type')
+    op.drop_column('organisation', 'crown')
+    op.drop_column('organisation', 'agreement_signed_version')
+    op.drop_column('organisation', 'agreement_signed_by_id')
+    op.drop_column('organisation', 'agreement_signed_at')
+    op.drop_column('organisation', 'agreement_signed')
+
+    op.drop_constraint('fk_organisation_email_branding_id', 'organisation', type_='foreignkey')
+    op.drop_column('organisation', 'email_branding_id')
+
+    op.drop_constraint('fk_organisation_letter_branding_id', 'organisation', type_='foreignkey')
+    op.drop_column('organisation', 'letter_branding_id')
+
+    op.drop_table('domain')

--- a/api/migrations/versions/0230_service_data_retention.py
+++ b/api/migrations/versions/0230_service_data_retention.py
@@ -1,0 +1,36 @@
+"""
+
+Revision ID: 0230
+Revises: 0229
+Create Date: 2019-07-09 21:25:05.103141
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = '0230'
+down_revision = '0229'
+
+
+def upgrade():
+    op.create_table('service_data_retention',
+                    sa.Column('id', postgresql.UUID(as_uuid=True), nullable=False),
+                    sa.Column('service_id', postgresql.UUID(as_uuid=True), nullable=False),
+                    sa.Column('notification_type', postgresql.ENUM(name='notification_type', create_type=False),
+                              nullable=False),
+                    sa.Column('days_of_retention', sa.Integer(), nullable=False),
+                    sa.Column('created_at', sa.DateTime(), nullable=False),
+                    sa.Column('updated_at', sa.DateTime(), nullable=True),
+                    sa.ForeignKeyConstraint(['service_id'], ['services.id'], ),
+                    sa.PrimaryKeyConstraint('id'),
+                    sa.UniqueConstraint('service_id', 'notification_type', name='uix_service_data_retention')
+                    )
+    op.create_index(op.f('ix_service_data_retention_service_id'), 'service_data_retention', ['service_id'],
+                    unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_service_data_retention_service_id'), table_name='service_data_retention')
+    op.drop_table('service_data_retention')


### PR DESCRIPTION
In preparation for large update. All DB changes can be made without
affecting existing data.