### PR TITLE
api/rate-limits: aggregate notification count

### DIFF
--- a/api/app/dao/services_dao.py
+++ b/api/app/dao/services_dao.py
@@ -444,9 +444,6 @@ def fetch_todays_total_message_count(service_id):
         Notification.service_id == service_id,
         Notification.key_type != KEY_TYPE_TEST,
         func.date(Notification.created_at) == datetime.utcnow().date()
-    ).group_by(
-        Notification.notification_type,
-        Notification.status,
     ).first()
     return 0 if result is None else result.count
 


### PR DESCRIPTION
across type, status, for the current day.

Results could be inconsistent depending on whether there were multiple
notification statuses out at the time of check, or even if there are
multiple templates per service.

This is a bug that is especially prominent when redis is disabled.

originally surfaced here:
  alphagov/notifications-api@e3d4185

This was introduced through a refactor to make this check more efficient --
Originally there was a helper function that collected some stats to be
displayed somewhere. This helper was also being used here to seed message
limit counts by totalling all the stats. When this was refactored it was
mistakenly decided to keep the "group by" clause BUT also to stop adding up
all the groups of stats.

We could have reverted to the old behaviour and added stats together
again, or just stop grouping.