### PR TITLE
admin: force user log out when signing in again

### DIFF
--- a/admin/app/__init__.py
+++ b/admin/app/__init__.py
@@ -432,9 +432,6 @@ def load_service_before_request():
 
         if service_id:
             try:
-                if not current_user.is_authenticated:
-                    return current_app.login_manager.unauthorized()
-
                 _request_ctx_stack.top.service = service_api_client.get_service(service_id)['data']
             except HTTPError as exc:
                 # if service id isn't real, then 404 rather than 500ing later because we expect service to be set

--- a/admin/app/main/views/sign_in.py
+++ b/admin/app/main/views/sign_in.py
@@ -8,7 +8,7 @@ from flask import (
     session,
     url_for,
 )
-from flask_login import current_user, logout_user
+from flask_login import current_user
 
 from app import invite_api_client, login_manager, user_api_client
 from app.main import main
@@ -80,9 +80,6 @@ def sign_in_sms(user_id, to):
 
 @login_manager.unauthorized_handler
 def sign_in_again():
-    session.clear()
-    logout_user()
-
     return redirect(
         url_for('main.sign_in', next=request.path)
     )

--- a/admin/app/main/views/sign_in.py
+++ b/admin/app/main/views/sign_in.py
@@ -8,7 +8,7 @@ from flask import (
     session,
     url_for,
 )
-from flask_login import current_user
+from flask_login import current_user, logout_user
 
 from app import invite_api_client, login_manager, user_api_client
 from app.main import main
@@ -80,6 +80,9 @@ def sign_in_sms(user_id, to):
 
 @login_manager.unauthorized_handler
 def sign_in_again():
+    session.clear()
+    logout_user()
+
     return redirect(
         url_for('main.sign_in', next=request.path)
     )

--- a/admin/tests/app/main/views/test_dashboard.py
+++ b/admin/tests/app/main/views/test_dashboard.py
@@ -70,29 +70,6 @@ def test_redirect_from_old_dashboard(
     assert expected_location == url_for('main.service_dashboard', service_id=SERVICE_ONE_ID, _external=True)
 
 
-def test_should_redirect_to_login_when_unauthenticated_and_valid_service_id(
-    client,
-    mocker,
-    service_one
-):
-    expected_location = 'http://localhost/sign-in?next=%2Fservices%2F{}'.format(SERVICE_ONE_ID)
-    response = client.get('/services/{}'.format(SERVICE_ONE_ID))
-
-    assert response.status_code == 302
-    assert response.location == expected_location
-
-
-def test_should_redirect_to_login_when_unauthenticated_and_invalid_service_id(
-    client,
-    mocker,
-    service_one
-):
-    expected_location = 'http://localhost/sign-in?next=%2Fservices%2F{}'.format('INVALID')
-    response = client.get('/services/{}'.format('INVALID'))
-
-    assert response.status_code == 302
-    assert response.location == expected_location    
-
 def test_get_started(
     logged_in_client,
     mocker,


### PR DESCRIPTION
We came across an issue with one session that was possibly corrupted. It
resulted in infinite redirects to the /sign-in page. This seems to have
been caused by the sign in route thinking that there is a current_user
and that the current_user.is_authenticated, however the Flask
login_required decorator disagreed with this state. This caused the
Flask decorator to redirect to the login_manager.unauthorized_handler
handler, which in turn would redirect back to /sign-in. This caused the
infinite redirect.

To fix this, we ensure that logout_user is called in the
unauthorized_handler. This should be OK since the user should already be
logged out if we enter this handler.