### PR TITLE
admin: add pages to find and archive users

### DIFF
--- a/admin/app/main/__init__.py
+++ b/admin/app/main/__init__.py
@@ -25,6 +25,7 @@ from app.main.views import (  # noqa
     manage_users,
     invites,
     feedback,
+    find_users,
     providers,
     platform_admin,
     letter_jobs,

--- a/admin/app/main/forms.py
+++ b/admin/app/main/forms.py
@@ -800,6 +800,16 @@ class DateFilterForm(StripWhitespaceForm):
     include_from_test_key = BooleanField("Include test keys", default="checked", false_values={"N"})
 
 
+class SearchUsersByEmailForm(StripWhitespaceForm):
+
+    search = SearchField(
+        'Search by name or email address',
+        validators=[
+            DataRequired("You need to enter full or partial email address to search by.")
+        ],
+    )
+
+
 class ChooseTemplateType(StripWhitespaceForm):
     template_type = RadioField(
         'What kind of template do you want to add?',
@@ -811,6 +821,7 @@ class ChooseTemplateType(StripWhitespaceForm):
             DataRequired()
         ]
     )
+
 
 class SearchTemplatesForm(StripWhitespaceForm):
 

--- a/admin/app/main/views/find_users.py
+++ b/admin/app/main/views/find_users.py
@@ -1,0 +1,46 @@
+from flask import flash, redirect, render_template, request, url_for
+from flask_login import current_user
+
+from app import user_api_client
+from app.main import main
+from app.main.forms import SearchUsersByEmailForm
+from app.models.user import User
+from app.utils import user_is_platform_admin
+
+
+@main.route("/find-users-by-email", methods=['GET', 'POST'])
+@user_is_platform_admin
+def find_users_by_email():
+    form = SearchUsersByEmailForm()
+    users_found = None
+    status = 200
+    if form.validate_on_submit():
+        users_found = user_api_client.find_users_by_full_or_partial_email(form.search.data)['data']
+    elif request.method == 'POST':
+        status = 400
+    return render_template(
+        'views/find-users/find-users-by-email.html',
+        form=form,
+        users_found=users_found
+    ), status
+
+
+@main.route("/users/<user_id>", methods=['GET'])
+@user_is_platform_admin
+def user_information(user_id):
+    return render_template(
+        'views/find-users/user-information.html',
+        user=User.from_id(user_id),
+    )
+
+
+@main.route("/users/<uuid:user_id>/archive", methods=['GET', 'POST'])
+@user_is_platform_admin
+def archive_user(user_id):
+    if request.method == 'POST':
+        user_api_client.archive_user(user_id)
+
+        return redirect(url_for('.user_information', user_id=user_id))
+    else:
+        flash('There\'s no way to reverse this! Are you sure you want to archive this user?', 'delete')
+        return user_information(user_id)

--- a/admin/app/models/__init__.py
+++ b/admin/app/models/__init__.py
@@ -1,0 +1,65 @@
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+
+from flask import abort
+
+
+class JSONModel():
+
+    ALLOWED_PROPERTIES = set()
+
+    def __init__(self, _dict):
+        # in the case of a bad request _dict may be `None`
+        self._dict = _dict or {}
+
+    def __bool__(self):
+        return self._dict != {}
+
+    def __hash__(self):
+        return hash(self.id)
+
+    def __eq__(self, other):
+        return self.id == other.id
+
+    def __getattr__(self, attr):
+        if attr in self.ALLOWED_PROPERTIES:
+            return self._dict[attr]
+        raise AttributeError('`{}` is not a {} attribute'.format(
+            attr,
+            self.__class__.__name__.lower(),
+        ))
+
+    def _get_by_id(self, things, id):
+        try:
+            return next(thing for thing in things if thing['id'] == str(id))
+        except StopIteration:
+            abort(404)
+
+
+class ModelList(ABC, Sequence):
+
+    @property
+    @abstractmethod
+    def client():
+        pass
+
+    @property
+    @abstractmethod
+    def model():
+        pass
+
+    def __init__(self):
+        self.items = self.client()
+
+    def __getitem__(self, index):
+        return self.model(self.items[index])
+
+    def __len__(self):
+        return len(self.items)
+
+    def __add__(self, other):
+        return list(self) + list(other)
+
+
+class InviteTokenError(Exception):
+    pass

--- a/admin/app/models/organisation.py
+++ b/admin/app/models/organisation.py
@@ -1,0 +1,189 @@
+from flask import Markup, abort
+from werkzeug.utils import cached_property
+
+from app.models import JSONModel, ModelList
+from app.notify_client.organisations_api_client import organisations_client
+
+
+class Organisation(JSONModel):
+
+    ALLOWED_PROPERTIES = {
+        'id',
+        'name',
+        'active',
+        'crown',
+        'organisation_type',
+        'letter_branding_id',
+        'email_branding_id',
+        'agreement_signed',
+        'agreement_signed_at',
+        'agreement_signed_by_id',
+        'agreement_signed_version',
+        'agreement_signed_on_behalf_of_name',
+        'agreement_signed_on_behalf_of_email_address',
+        'domains',
+        'request_to_go_live_notes',
+        'count_of_live_services',
+    }
+
+    @classmethod
+    def from_id(cls, org_id):
+        return cls(organisations_client.get_organisation(org_id))
+
+    @classmethod
+    def from_domain(cls, domain):
+        return cls(organisations_client.get_organisation_by_domain(domain))
+
+    @classmethod
+    def from_service(cls, service_id):
+        return cls(organisations_client.get_service_organisation(service_id))
+
+    @classmethod
+    def create_from_form(cls, form):
+        return cls.create(
+            name=form.name.data,
+            crown={
+                'crown': True,
+                'non-crown': False,
+                'unknown': None,
+            }.get(form.crown_status.data),
+            organisation_type=form.organisation_type.data,
+        )
+
+    @classmethod
+    def create(cls, name, crown, organisation_type, agreement_signed=False):
+        return cls(organisations_client.create_organisation(
+            name=name,
+            crown=crown,
+            organisation_type=organisation_type,
+            agreement_signed=agreement_signed,
+        ))
+
+    def __init__(self, _dict):
+
+        super().__init__(_dict)
+
+        if self._dict == {}:
+            self.name = None
+            self.crown = None
+            self.agreement_signed = None
+            self.domains = []
+            self.organisation_type = None
+            self.request_to_go_live_notes = None
+
+    def as_human_readable(self, fallback_domain):
+        if self.agreement_signed:
+            agreement_statement = 'Yes, on behalf of {}.'.format(self.name)
+        elif self.name:
+            agreement_statement = '{} (organisation is {}, {}).'.format(
+                {
+                    False: 'No',
+                    None: 'Can’t tell',
+                }.get(self.agreement_signed),
+                self.name,
+                {
+                    True: 'a crown body',
+                    False: 'a non-crown body',
+                    None: 'crown status unknown',
+                }.get(self.crown),
+            )
+        else:
+            agreement_statement = 'Can’t tell (domain is {}).'.format(fallback_domain)
+
+        if self.request_to_go_live_notes:
+            agreement_statement = agreement_statement + ' ' + self.request_to_go_live_notes
+
+        return agreement_statement
+
+    def as_info_for_branding_request(self, fallback_domain):
+        return self.name or 'Can’t tell (domain is {})'.format(fallback_domain)
+
+    @property
+    def as_jinja_template(self):
+        if self.crown is None:
+            return 'agreement-choose'
+        if self.agreement_signed:
+            return 'agreement-signed'
+        return 'agreement'
+
+    def as_terms_of_use_paragraph(self, **kwargs):
+        return Markup(self._as_terms_of_use_paragraph(**kwargs))
+
+    def _as_terms_of_use_paragraph(self, terms_link, download_link, support_link, signed_in):
+
+        if not signed_in:
+            return ((
+                '{} <a href="{}">Sign in</a> to download a copy '
+                'or find out if one is already in place.'
+            ).format(self._acceptance_required, terms_link))
+
+        if self.agreement_signed is None:
+            return ((
+                '{} <a href="{}">Download the agreement</a> or '
+                '<a href="{}">contact us</a> to find out if we already '
+                'have one in place with your organisation.'
+            ).format(self._acceptance_required, download_link, support_link))
+
+        if self.agreement_signed is False:
+            return ((
+                '{} <a href="{}">Download a copy</a>.'
+            ).format(self._acceptance_required, download_link))
+
+        return (
+            'Your organisation ({}) has already accepted the '
+            'GOV.UK&nbsp;Notify data sharing and financial '
+            'agreement.'.format(self.name)
+        )
+
+    @property
+    def _acceptance_required(self):
+        return (
+            'Your organisation {} must also accept our data sharing '
+            'and financial agreement.'.format(
+                '({})'.format(self.name) if self.name else '',
+            )
+        )
+
+    @property
+    def crown_status_or_404(self):
+        if self.crown is None:
+            abort(404)
+        return self.crown
+
+    @cached_property
+    def services(self):
+        return organisations_client.get_organisation_services(self.id)
+
+    @property
+    def live_services(self):
+        return [s for s in self.services if s['active'] and not s['restricted']]
+
+    @property
+    def trial_services(self):
+        return [s for s in self.services if not s['active'] or s['restricted']]
+
+    @cached_property
+    def invited_users(self):
+        from app.models.user import OrganisationInvitedUsers
+        return OrganisationInvitedUsers(self.id)
+
+    @cached_property
+    def active_users(self):
+        from app.models.user import OrganisationUsers
+        return OrganisationUsers(self.id)
+
+    @cached_property
+    def team_members(self):
+        return sorted(
+            self.invited_users + self.active_users,
+            key=lambda user: user.email_address.lower(),
+        )
+
+    def update(self, **kwargs):
+        response = organisations_client.update_organisation(self.id, **kwargs)
+        self.__init__(response)
+
+
+class Organisations(ModelList):
+    client = organisations_client.get_organisations
+    model = Organisation

--- a/admin/app/models/roles_and_permissions.py
+++ b/admin/app/models/roles_and_permissions.py
@@ -1,0 +1,44 @@
+from itertools import chain
+
+roles = {
+    'send_messages': ['send_texts', 'send_emails', 'send_letters'],
+    'manage_templates': ['manage_templates'],
+    'manage_service': ['manage_users', 'manage_settings'],
+    'manage_api_keys': ['manage_api_keys'],
+    'view_activity': ['view_activity'],
+}
+
+# same dict as above, but flipped round
+roles_by_permission = {
+    permission: next(
+        role for role, permissions in roles.items() if permission in permissions
+    ) for permission in chain(*list(roles.values()))
+}
+
+all_permissions = set(roles_by_permission.values())
+
+permissions = (
+    ('view_activity', 'See dashboard'),
+    ('send_messages', 'Send messages'),
+    ('manage_templates', 'Add and edit templates'),
+    ('manage_service', 'Manage settings, team and usage'),
+    ('manage_api_keys', 'Manage API integration'),
+)
+
+
+def translate_permissions_from_db_to_admin_roles(permissions):
+    """
+    Given a list of database permissions, return a set of roles
+
+    look them up in roles_by_permission, falling back to just passing through from the api if they aren't in the dict
+    """
+    return {roles_by_permission.get(permission, permission) for permission in permissions}
+
+
+def translate_permissions_from_admin_roles_to_db(permissions):
+    """
+    Given a list of admin roles (ie: checkboxes on a permissions edit page for example), return a set of db permissions
+
+    Looks them up in the roles dict, falling back to just passing through if they're not recognised.
+    """
+    return set(chain.from_iterable(roles.get(permission, [permission]) for permission in permissions))

--- a/admin/app/models/service.py
+++ b/admin/app/models/service.py
@@ -1,0 +1,561 @@
+from flask import abort, current_app
+from notifications_utils.field import Field
+from werkzeug.utils import cached_property
+
+from app.models import JSONModel
+from app.models.organisation import Organisation
+from app.models.user import InvitedUsers, User, Users
+from app.notify_client.api_key_api_client import api_key_api_client
+from app.notify_client.billing_api_client import billing_api_client
+from app.notify_client.email_branding_client import email_branding_client
+from app.notify_client.inbound_number_client import inbound_number_client
+from app.notify_client.invite_api_client import invite_api_client
+from app.notify_client.job_api_client import job_api_client
+from app.notify_client.service_api_client import service_api_client
+
+
+class Service(JSONModel):
+
+    ALLOWED_PROPERTIES = {
+        'active',
+        'contact_link',
+        'email_branding',
+        'email_from',
+        'id',
+        'inbound_api',
+        'letter_branding',
+        'letter_contact_block',
+        'message_limit',
+        'name',
+        'organisation_type',
+        'permissions',
+        'prefix_sms',
+        'research_mode',
+        'service_callback_api',
+        'volume_email',
+        'volume_sms',
+        'volume_letter',
+        'consent_to_research',
+        'count_as_live',
+        'go_live_user',
+        'go_live_at'
+    }
+
+    TEMPLATE_TYPES = (
+        'email',
+        'sms',
+        'letter',
+    )
+
+    def __init__(self, _dict):
+
+        super().__init__(_dict)
+        if 'permissions' not in self._dict:
+            self.permissions = {'email', 'sms', 'letter'}
+
+    @classmethod
+    def from_id(cls, service_id):
+        return cls(service_api_client.get_service(service_id)['data'])
+
+    def update(self, **kwargs):
+        return service_api_client.update_service(self.id, **kwargs)
+
+    def update_status(self, live):
+        return service_api_client.update_status(self.id, live=live)
+
+    def switch_permission(self, permission):
+        return self.force_permission(
+            permission,
+            on=not self.has_permission(permission),
+        )
+
+    def force_permission(self, permission, on=False):
+
+        permissions, permission = set(self.permissions), {permission}
+
+        return self.update_permissions(
+            permissions | permission if on else permissions - permission,
+        )
+
+    def update_permissions(self, permissions):
+        return self.update(permissions=list(permissions))
+
+    def toggle_research_mode(self):
+        self.update(research_mode=not self.research_mode)
+
+    @property
+    def trial_mode(self):
+        return self._dict['restricted']
+
+    @property
+    def live(self):
+        return not self.trial_mode
+
+    def has_permission(self, permission):
+        return permission in self.permissions
+
+    @cached_property
+    def has_jobs(self):
+        return job_api_client.has_jobs(self.id)
+
+    @cached_property
+    def invited_users(self):
+        return InvitedUsers(self.id)
+
+    @cached_property
+    def active_users(self):
+        return Users(self.id)
+
+    @cached_property
+    def team_members(self):
+        return sorted(
+            self.invited_users + self.active_users,
+            key=lambda user: user.email_address.lower(),
+        )
+
+    @cached_property
+    def has_team_members(self):
+        return len([
+            user for user in self.team_members
+            if user.has_permission_for_service(self.id, 'manage_service')
+        ]) > 1
+
+    def cancel_invite(self, invited_user_id):
+        if str(invited_user_id) not in {user.id for user in self.invited_users}:
+            abort(404)
+
+        return invite_api_client.cancel_invited_user(
+            service_id=self.id,
+            invited_user_id=str(invited_user_id),
+        )
+
+    def get_team_member(self, user_id):
+
+        if str(user_id) not in {user.id for user in self.active_users}:
+            abort(404)
+
+        return User.from_id(user_id)
+
+    @cached_property
+    def all_templates(self):
+
+        templates = service_api_client.get_service_templates(self.id)['data']
+
+        return [
+            template for template in templates
+            if template['template_type'] in self.available_template_types
+        ]
+
+    @cached_property
+    def all_template_ids(self):
+        return {template['id'] for template in self.all_templates}
+
+    def get_templates(self, template_type='all', template_folder_id=None, user=None):
+        if user and template_folder_id:
+            folder = self.get_template_folder(template_folder_id)
+            if not user.has_template_folder_permission(folder):
+                return []
+
+        if isinstance(template_type, str):
+            template_type = [template_type]
+        if template_folder_id:
+            template_folder_id = str(template_folder_id)
+        return [
+            template for template in self.all_templates
+            if (set(template_type) & {'all', template['template_type']})
+            and template.get('folder') == template_folder_id
+        ]
+
+    def get_template(self, template_id, version=None):
+        return service_api_client.get_service_template(self.id, str(template_id), version)['data']
+
+    def get_template_folder_with_user_permission_or_403(self, folder_id, user):
+        template_folder = self.get_template_folder(folder_id)
+
+        if not user.has_template_folder_permission(template_folder):
+            abort(403)
+
+        return template_folder
+
+    def get_template_with_user_permission_or_403(self, template_id, user):
+        template = self.get_template(template_id)
+
+        self.get_template_folder_with_user_permission_or_403(template['folder'], user)
+
+        return template
+
+    @property
+    def available_template_types(self):
+        return list(filter(self.has_permission, self.TEMPLATE_TYPES))
+
+    @property
+    def has_templates(self):
+        return bool(self.all_templates)
+
+    def has_folders(self):
+        return bool(self.all_template_folders)
+
+    @property
+    def has_multiple_template_types(self):
+        return len({
+            template['template_type'] for template in self.all_templates
+        }) > 1
+
+    @property
+    def has_estimated_usage(self):
+        return (
+            self.consent_to_research is not None and any((
+                self.volume_email,
+                self.volume_sms,
+                self.volume_letter,
+            ))
+        )
+
+    @property
+    def has_email_templates(self):
+        return len(self.get_templates('email')) > 0
+
+    @property
+    def has_sms_templates(self):
+        return len(self.get_templates('sms')) > 0
+
+    @property
+    def intending_to_send_email(self):
+        if self.volume_email is None:
+            return self.has_email_templates
+        return self.volume_email > 0
+
+    @property
+    def intending_to_send_sms(self):
+        if self.volume_sms is None:
+            return self.has_sms_templates
+        return self.volume_sms > 0
+
+    @cached_property
+    def email_reply_to_addresses(self):
+        return service_api_client.get_reply_to_email_addresses(self.id)
+
+    @property
+    def has_email_reply_to_address(self):
+        return bool(self.email_reply_to_addresses)
+
+    @property
+    def count_email_reply_to_addresses(self):
+        return len(self.email_reply_to_addresses)
+
+    @property
+    def default_email_reply_to_address(self):
+        return next(
+            (
+                x['email_address']
+                for x in self.email_reply_to_addresses if x['is_default']
+            ), None
+        )
+
+    def get_email_reply_to_address(self, id):
+        return service_api_client.get_reply_to_email_address(self.id, id)
+
+    @property
+    def needs_to_add_email_reply_to_address(self):
+        return self.intending_to_send_email and not self.has_email_reply_to_address
+
+    @property
+    def shouldnt_use_govuk_as_sms_sender(self):
+        return self.organisation_type in {'local', 'nhs'}
+
+    @cached_property
+    def sms_senders(self):
+        return service_api_client.get_sms_senders(self.id)
+
+    @property
+    def sms_senders_with_hints(self):
+
+        def attach_hint(sender):
+            hints = []
+            if sender['is_default']:
+                hints += ["default"]
+            if sender['inbound_number_id']:
+                hints += ["receives replies"]
+            if hints:
+                sender['hint'] = "(" + " and ".join(hints) + ")"
+            return sender
+
+        return [attach_hint(sender) for sender in self.sms_senders]
+
+    @property
+    def default_sms_sender(self):
+        return None
+
+    @property
+    def count_sms_senders(self):
+        return len(self.sms_senders)
+
+    @property
+    def sms_sender_is_govuk(self):
+        return self.default_sms_sender in {'GOVUK', 'None'}
+
+    def get_sms_sender(self, id):
+        return service_api_client.get_sms_sender(self.id, id)
+
+    @property
+    def needs_to_change_sms_sender(self):
+        return all((
+            self.intending_to_send_sms,
+            self.shouldnt_use_govuk_as_sms_sender,
+            self.sms_sender_is_govuk,
+        ))
+
+    @cached_property
+    def letter_contact_details(self):
+        return service_api_client.get_letter_contacts(self.id)
+
+    @property
+    def count_letter_contact_details(self):
+        return len(self.letter_contact_details)
+
+    @property
+    def default_letter_contact_block(self):
+        return next(
+            (
+                Field(x['contact_block'], html='escape')
+                for x in self.letter_contact_details if x['is_default']
+            ), None
+        )
+
+    def get_letter_contact_block(self, id):
+        return service_api_client.get_letter_contact(self.id, id)
+
+    @property
+    def volumes(self):
+        return sum(filter(None, (
+            self.volume_email,
+            self.volume_sms,
+            self.volume_letter,
+        )))
+
+    @property
+    def go_live_checklist_completed(self):
+        return all((
+            bool(self.volumes),
+            self.has_team_members,
+            self.has_templates,
+            not self.needs_to_add_email_reply_to_address,
+            not self.needs_to_change_sms_sender,
+        ))
+
+    @property
+    def go_live_checklist_completed_as_yes_no(self):
+        return 'Yes' if self.go_live_checklist_completed else 'No'
+
+    @cached_property
+    def free_sms_fragment_limit(self):
+        return billing_api_client.get_free_sms_fragment_limit_for_year(self.id) or 0
+
+    @cached_property
+    def data_retention(self):
+        return service_api_client.get_service_data_retention(self.id)
+
+    def get_data_retention_item(self, id):
+        return next(
+            (dr for dr in self.data_retention if dr['id'] == id),
+            None
+        )
+
+    def get_days_of_retention(self, notification_type):
+        return next(
+            (dr for dr in self.data_retention if dr['notification_type'] == notification_type),
+            {}
+        ).get('days_of_retention', current_app.config['ACTIVITY_STATS_LIMIT_DAYS'])
+
+    @property
+    def email_branding_id(self):
+        return self._dict['email_branding']
+
+    @cached_property
+    def email_branding(self):
+        if self.email_branding_id:
+            return email_branding_client.get_email_branding(self.email_branding_id)['email_branding']
+        return None
+
+    @cached_property
+    def email_branding_name(self):
+        if self.email_branding is None:
+            return 'GOV.UK'
+        return self.email_branding['name']
+
+    @property
+    def letter_branding_id(self):
+        return self._dict['letter_branding']
+
+    @cached_property
+    def letter_branding(self):
+        return None
+
+    @cached_property
+    def organisation(self):
+        return Organisation.from_service(self.id)
+
+    @property
+    def organisation_id(self):
+        return self._dict['organisation']
+
+    @cached_property
+    def inbound_number(self):
+        return inbound_number_client.get_inbound_sms_number_for_service(self.id)['data'].get('number', '')
+
+    @property
+    def has_inbound_number(self):
+        return bool(self.inbound_number)
+
+    @cached_property
+    def all_template_folders(self):
+        return []
+
+    @cached_property
+    def all_template_folder_ids(self):
+        return {folder['id'] for folder in self.all_template_folders}
+
+    def get_user_template_folders(self, user):
+        """Returns a modified list of folders a user has permission to view
+
+        For each folder, we do the following:
+        - if user has no permission to view the folder, skip it
+        - if folder is visible and its parent is visible, we add it to the list of folders
+        we later return without modifying anything
+        - if folder is visible, but the parent is not, we iterate through the parent until we
+        either find a visible parent or reach root folder. On each iteration we concatenate
+        invisible parent folder name to the front of our folder name, modifying the name, and we
+        change parent_folder_id attribute to a higher level parent. This flattens the path to the
+        folder making sure it displays in the closest visible parent.
+
+        """
+        user_folders = []
+        for folder in self.all_template_folders:
+            if not user.has_template_folder_permission(folder, service=self):
+                continue
+            parent = self.get_template_folder(folder["parent_id"])
+            if user.has_template_folder_permission(parent, service=self):
+                user_folders.append(folder)
+            else:
+                folder_attrs = {
+                    "id": folder["id"], "name": folder["name"], "parent_id": folder["parent_id"],
+                    "users_with_permission": folder["users_with_permission"]
+                }
+                while folder_attrs["parent_id"] is not None:
+                    folder_attrs["name"] = parent["name"] + " / " + folder_attrs["name"]
+                    if parent["parent_id"] is None:
+                        folder_attrs["parent_id"] = None
+                    else:
+                        parent = self.get_template_folder(parent["parent_id"])
+                        folder_attrs["parent_id"] = parent.get("id", None)
+                        if user.has_template_folder_permission(parent, service=self):
+                            break
+                user_folders.append(folder_attrs)
+        return user_folders
+
+    def get_template_folders(self, template_type='all', parent_folder_id=None, user=None):
+        if user:
+            folders = self.get_user_template_folders(user)
+        else:
+            folders = self.all_template_folders
+        if parent_folder_id:
+            parent_folder_id = str(parent_folder_id)
+
+        return [
+            folder for folder in folders
+            if (
+                folder['parent_id'] == parent_folder_id
+                and self.is_folder_visible(folder['id'], template_type, user)
+            )
+        ]
+
+    def get_template_folder(self, folder_id):
+        if folder_id is None:
+            return {
+                'id': None,
+                'name': 'Templates',
+                'parent_id': None,
+            }
+        return self._get_by_id(self.all_template_folders, folder_id)
+
+    def is_folder_visible(self, template_folder_id, template_type='all', user=None):
+
+        if template_type == 'all':
+            return True
+
+        if self.get_templates(template_type, template_folder_id):
+            return True
+
+        if any(
+            self.is_folder_visible(child_folder['id'], template_type, user)
+            for child_folder in self.get_template_folders(template_type, template_folder_id, user)
+        ):
+            return True
+
+        return False
+
+    def get_template_folder_path(self, template_folder_id):
+
+        folder = self.get_template_folder(template_folder_id)
+
+        if folder['id'] is None:
+            return [folder]
+
+        return self.get_template_folder_path(folder['parent_id']) + [
+            self.get_template_folder(folder['id'])
+        ]
+
+    def get_template_path(self, template):
+        return self.get_template_folder_path(template['folder']) + [
+            template,
+        ]
+
+    def get_template_folders_and_templates(self, template_type, template_folder_id):
+        return (
+            self.get_templates(template_type, template_folder_id)
+            + self.get_template_folders(template_type, template_folder_id)
+        )
+
+    @property
+    def count_of_templates_and_folders(self):
+        return len(self.all_templates + self.all_template_folders)
+
+    def move_to_folder(self, ids_to_move, move_to):
+        pass
+
+    @cached_property
+    def api_keys(self):
+        return sorted(
+            api_key_api_client.get_api_keys(self.id)['apiKeys'],
+            key=lambda key: key['name'].lower(),
+        )
+
+    def get_api_key(self, id):
+        return self._get_by_id(self.api_keys, id)
+
+    @property
+    def request_to_go_live_tags(self):
+        return list(self._get_request_to_go_live_tags())
+
+    def _get_request_to_go_live_tags(self):
+
+        BASE = 'notify_request_to_go_live'
+
+        yield BASE
+
+        if self.go_live_checklist_completed and self.organisation.agreement_signed:
+            yield BASE + '_complete'
+            return
+
+        for test, tag in (
+            (True, ''),
+            (not self.volumes, '_volumes'),
+            (not self.go_live_checklist_completed, '_checklist'),
+            (not self.organisation.agreement_signed, '_mou'),
+            (self.needs_to_add_email_reply_to_address, '_email_reply_to'),
+            (not self.has_team_members, '_team_member'),
+            (not self.has_templates, '_template_content'),
+            (self.needs_to_change_sms_sender, '_sms_sender'),
+        ):
+            if test:
+                yield BASE + '_incomplete' + tag

--- a/admin/app/models/template_list.py
+++ b/admin/app/models/template_list.py
@@ -1,0 +1,194 @@
+class TemplateList():
+
+    def __init__(
+        self,
+        service,
+        template_type='all',
+        template_folder_id=None,
+        user=None,
+    ):
+        self.service = service
+        self.template_type = template_type
+        self.template_folder_id = template_folder_id
+        self.user = user
+
+    def __iter__(self):
+        for item in self.get_templates_and_folders(
+            self.template_type, self.template_folder_id, self.user, ancestors=[]
+        ):
+            yield item
+
+    def get_templates_and_folders(self, template_type, template_folder_id, user, ancestors):
+
+        for item in self.service.get_template_folders(
+            template_type, template_folder_id, user,
+        ):
+            yield TemplateListFolder(
+                item,
+                folders=self.service.get_template_folders(
+                    template_type, item['id'], user
+                ),
+                templates=self.service.get_templates(
+                    template_type, item['id']
+                ),
+                ancestors=ancestors,
+                service_id=self.service.id,
+            )
+            for sub_item in self.get_templates_and_folders(
+                template_type, item['id'], user, ancestors + [item]
+            ):
+                yield sub_item
+
+        for item in self.service.get_templates(
+            template_type, template_folder_id, user
+        ):
+            yield TemplateListTemplate(
+                item,
+                ancestors=ancestors,
+                service_id=self.service.id,
+            )
+
+    @property
+    def as_id_and_name(self):
+        return [(item.id, item.name) for item in self]
+
+    @property
+    def templates_to_show(self):
+        return any(self)
+
+    @property
+    def folder_is_empty(self):
+        return not any(self.get_templates_and_folders(
+            'all', self.template_folder_id, self.user, []
+        ))
+
+
+class TemplateLists():
+
+    def __init__(self, user):
+        self.services = sorted(
+            user.services,
+            key=lambda service: service.name.lower(),
+        )
+        self.user = user
+
+    def __iter__(self):
+
+        if len(self.services) == 1:
+
+            for template_or_folder in TemplateList(self.services[0], user=self.user):
+                yield template_or_folder
+
+            return
+
+        for service in self.services:
+
+            template_list_service = TemplateListService(service)
+
+            yield template_list_service
+
+            for service_templates_and_folders in TemplateList(
+                service, user=self.user
+            ).get_templates_and_folders(
+                template_type='all',
+                template_folder_id=None,
+                user=self.user,
+                ancestors=[template_list_service],
+            ):
+                yield service_templates_and_folders
+
+    @property
+    def templates_to_show(self):
+        return bool(self.services)
+
+
+class TemplateListItem():
+
+    is_service = False
+
+    def __init__(
+        self,
+        template_or_folder,
+        ancestors,
+    ):
+        self.id = template_or_folder['id']
+        self.name = template_or_folder['name']
+        self.ancestors = ancestors
+
+
+class TemplateListTemplate(TemplateListItem):
+
+    is_folder = False
+
+    def __init__(
+        self,
+        template,
+        ancestors,
+        service_id,
+    ):
+        super().__init__(template, ancestors)
+        self.service_id = service_id
+        self.hint = {
+            'email': 'Email template',
+            'sms': 'Text message template',
+            'letter': 'Letter template',
+        }.get(template['template_type'])
+
+
+class TemplateListFolder(TemplateListItem):
+
+    is_folder = True
+
+    def __init__(
+        self,
+        folder,
+        templates,
+        folders,
+        ancestors,
+        service_id,
+    ):
+        super().__init__(folder, ancestors)
+        self.service_id = service_id
+        self.number_of_templates = len(templates)
+        self.number_of_folders = len(folders)
+
+    @property
+    def _hint_parts(self):
+
+        if self.number_of_folders == self.number_of_templates == 0:
+            yield 'Empty'
+
+        if self.number_of_templates == 1:
+            yield '1 template'
+        elif self.number_of_templates > 1:
+            yield '{} templates'.format(self.number_of_templates)
+
+        if self.number_of_folders == 1:
+            yield '1 folder'
+        elif self.number_of_folders > 1:
+            yield '{} folders'.format(self.number_of_folders)
+
+    @property
+    def hint(self):
+        return ', '.join(self._hint_parts)
+
+
+class TemplateListService(TemplateListFolder):
+
+    is_service = True
+
+    def __init__(
+        self,
+        service,
+    ):
+        super().__init__(
+            folder=service._dict,
+            templates=service.get_templates(
+                template_folder_id=None,
+            ),
+            folders=service.get_template_folders(
+                parent_folder_id=None,
+            ),
+            ancestors=[],
+            service_id=service.id,
+        )

--- a/admin/app/models/user.py
+++ b/admin/app/models/user.py
@@ -1,0 +1,632 @@
+from flask import abort, current_app, request, session
+from flask_login import AnonymousUserMixin, UserMixin, login_user
+from notify.errors import HTTPError
+from werkzeug.utils import cached_property
+
+from app.models import JSONModel, ModelList
+from app.models.organisation import Organisation
+from app.models.roles_and_permissions import (
+    all_permissions,
+    translate_permissions_from_db_to_admin_roles,
+)
+from app.notify_client import InviteTokenError
+from app.notify_client.invite_api_client import invite_api_client
+from app.notify_client.org_invite_api_client import org_invite_api_client
+from app.notify_client.user_api_client import user_api_client
+from app.utils import is_gov_user
+
+
+def _get_service_id_from_view_args():
+    return str(request.view_args.get('service_id', '')) or None
+
+
+def _get_org_id_from_view_args():
+    return str(request.view_args.get('org_id', '')) or None
+
+
+class User(JSONModel, UserMixin):
+
+    ALLOWED_PROPERTIES = {
+        'id',
+        'name',
+        'email_address',
+        'auth_type',
+        'current_session_id',
+        'failed_login_count',
+        'logged_in_at',
+        'mobile_number',
+        'password_changed_at',
+        'permissions',
+        'platform_admin',
+        'state',
+    }
+
+    def __init__(self, _dict):
+        super().__init__(_dict)
+        self.permissions = _dict.get('permissions', {})
+        self.max_failed_login_count = current_app.config['MAX_FAILED_LOGIN_COUNT']
+        self._platform_admin = _dict['platform_admin']
+
+    @classmethod
+    def from_id(cls, user_id):
+        return cls(user_api_client.TODO_get_user(user_id))
+
+    @classmethod
+    def from_email_address(cls, email_address):
+        return cls(user_api_client.get_user_by_email(email_address))
+
+    @classmethod
+    def from_email_address_or_none(cls, email_address):
+        response = user_api_client.get_user_by_email_or_none(email_address)
+        if response:
+            return cls(response)
+        return None
+
+    @staticmethod
+    def already_registered(email_address):
+        return bool(User.from_email_address_or_none(email_address))
+
+    @classmethod
+    def from_email_address_and_password_or_none(cls, email_address, password):
+        user = cls.from_email_address_or_none(email_address)
+        if not user:
+            return None
+        if user.locked:
+            return None
+        if not user_api_client.verify_password(user.id, password):
+            return None
+        return user
+
+    @property
+    def permissions(self):
+        return self._permissions
+
+    @permissions.setter
+    def permissions(self, permissions_by_service):
+        """
+        Permissions is a dict {'service_id': ['permission a', 'permission b', 'permission c']}
+
+        The api currently returns some granular permissions that we don't set or use separately (but may want
+        to in the future):
+        * send_texts, send_letters and send_emails become send_messages
+        * manage_user and manage_settings become
+        users either have all three permissions for a service or none of them, they're not helpful to distinguish
+        between on the front end. So lets collapse them into "send_messages" and "manage_service". If we want to split
+        them out later, we'll need to rework this function.
+        """
+        self._permissions = {
+            service: translate_permissions_from_db_to_admin_roles(permissions)
+            for service, permissions
+            in permissions_by_service.items()
+        }
+
+    def update(self, **kwargs):
+        response = user_api_client.update_user_attribute(self.id, **kwargs)
+        self.__init__(response)
+
+    def update_password(self, password):
+        response = user_api_client.update_password(self.id, password)
+        self.__init__(response)
+
+    def set_permissions(self, service_id, permissions, folder_permissions):
+        user_api_client.set_user_permissions(
+            self.id,
+            service_id,
+            permissions=permissions,
+            folder_permissions=folder_permissions,
+        )
+
+    def logged_in_elsewhere(self):
+        # if the current user (ie: db object) has no session, they've never logged in before
+        return self.current_session_id is not None and session.get('current_session_id') != self.current_session_id
+
+    def activate(self):
+        if self.state == 'pending':
+            user_data = user_api_client.activate_user(self.id)
+            return self.__class__(user_data['data'])
+        else:
+            return self
+
+    def login(self):
+        login_user(self)
+
+    def sign_in(self):
+
+        session['user_details'] = {"email": self.email_address, "id": self.id}
+
+        if not self.is_active:
+            return False
+
+        if self.email_auth:
+            user_api_client.send_verify_code(self.id, 'email', None, request.args.get('next'))
+        if self.sms_auth:
+            user_api_client.send_verify_code(self.id, 'sms', self.mobile_number)
+
+        return True
+
+    @property
+    def sms_auth(self):
+        return self.auth_type == 'sms_auth'
+
+    @property
+    def email_auth(self):
+        return self.auth_type == 'email_auth'
+
+    def reset_failed_login_count(self):
+        user_api_client.reset_failed_login_count(self.id)
+
+    @property
+    def is_active(self):
+        return self.state == 'active'
+
+    @property
+    def is_gov_user(self):
+        return is_gov_user(self.email_address)
+
+    @property
+    def is_authenticated(self):
+        return (
+            not self.logged_in_elsewhere() and
+            super(User, self).is_authenticated
+        )
+
+    @property
+    def platform_admin(self):
+        return self._platform_admin and not session.get('disable_platform_admin_view', False)
+
+    def has_permissions(self, *permissions, restrict_admin_usage=False, allow_org_user=False):
+        unknown_permissions = set(permissions) - all_permissions
+        if unknown_permissions:
+            raise TypeError('{} are not valid permissions'.format(list(unknown_permissions)))
+
+        # Service id is always set on the request for service specific views.
+        service_id = _get_service_id_from_view_args()
+        org_id = _get_org_id_from_view_args()
+
+        if not service_id and not org_id:
+            # we shouldn't have any pages that require permissions, but don't specify a service or organisation.
+            # use @user_is_platform_admin for platform admin only pages
+            raise NotImplementedError
+
+        # platform admins should be able to do most things (except eg send messages, or create api keys)
+        if self.platform_admin and not restrict_admin_usage:
+            return True
+
+        if org_id:
+            return self.belongs_to_organisation(org_id)
+
+        if not permissions and self.belongs_to_service(service_id):
+            return True
+
+        if any(
+            self.has_permission_for_service(service_id, permission)
+            for permission in permissions
+        ):
+            return True
+
+        from app.models.service import Service
+
+        return allow_org_user and self.belongs_to_organisation(
+            Service.from_id(service_id).organisation_id
+        )
+
+    def has_permission_for_service(self, service_id, permission):
+        return permission in self._permissions.get(service_id, [])
+
+    def has_template_folder_permission(self, template_folder, service=None):
+        if self.platform_admin:
+            return True
+
+        # Top-level templates are always visible
+        if template_folder is None or template_folder['id'] is None:
+            return True
+
+        return self.id in template_folder.get("users_with_permission", [])
+
+    def template_folders_for_service(self, service=None):
+        """
+        Returns list of template folders that a user can view for a given service
+        """
+        return [
+            template_folder
+            for template_folder in service.all_template_folders
+            if self.id in template_folder.get("users_with_permission", [])
+        ]
+
+    def belongs_to_service(self, service_id):
+        return str(service_id) in self.service_ids
+
+    def belongs_to_service_or_403(self, service_id):
+        if not self.belongs_to_service(service_id):
+            abort(403)
+
+    def belongs_to_organisation(self, organisation_id):
+        return str(organisation_id) in self.organisation_ids
+
+    @property
+    def locked(self):
+        return self.failed_login_count >= self.max_failed_login_count
+
+    @property
+    def email_domain(self):
+        return self.email_address.split('@')[-1]
+
+    @cached_property
+    def orgs_and_services(self):
+        return user_api_client.get_organisations_and_services_for_user(self.id)
+
+    @staticmethod
+    def sort_services(services):
+        return sorted(services, key=lambda service: service.name.lower())
+
+    @property
+    def services(self):
+        from app.models.service import Service
+        return self.sort_services([
+            Service(service) for service in self.orgs_and_services['services']
+        ])
+
+    @property
+    def services_with_organisation(self):
+        return [
+            service for service in self.services
+            if self.belongs_to_organisation(service.organisation_id)
+        ]
+
+    @property
+    def services_without_organisations(self):
+        return [
+            service for service in self.services
+            if not self.belongs_to_organisation(service.organisation_id)
+        ]
+
+    @property
+    def service_ids(self):
+        return self._dict['services']
+
+    @property
+    def trial_mode_services(self):
+        return [
+            service for service in self.services if service.trial_mode
+        ]
+
+    @property
+    def live_services(self):
+        return [
+            service for service in self.services if service.live
+        ]
+
+    @property
+    def live_services_not_belonging_to_users_organisations(self):
+        return self.sort_services(
+            set(self.live_services).union(self.services_without_organisations)
+        )
+
+    @property
+    def organisations(self):
+        return [
+            Organisation(organisation)
+            for organisation in self.orgs_and_services['organisations']
+        ]
+
+    @property
+    def organisation_ids(self):
+        return self._dict['organisations']
+
+    @cached_property
+    def default_organisation(self):
+        return Organisation.from_domain(self.email_domain)
+
+    @property
+    def default_organisation_type(self):
+        if self.default_organisation:
+            return self.default_organisation.organisation_type
+        if self.has_nhs_email_address:
+            return 'nhs'
+        return None
+
+    @property
+    def has_access_to_live_and_trial_mode_services(self):
+        return (
+            self.organisations or self.live_services
+        ) and (
+            self.trial_mode_services
+        )
+
+    @property
+    def has_nhs_email_address(self):
+        return self.email_address.lower().endswith((
+            '@nhs.uk', '.nhs.uk', '@nhs.net', '.nhs.net',
+        ))
+
+    def serialize(self):
+        dct = {
+            "id": self.id,
+            "name": self.name,
+            "email_address": self.email_address,
+            "mobile_number": self.mobile_number,
+            "password_changed_at": self.password_changed_at,
+            "state": self.state,
+            "failed_login_count": self.failed_login_count,
+            "permissions": [x for x in self._permissions],
+            "organisations": self.organisation_ids,
+            "current_session_id": self.current_session_id
+        }
+        if hasattr(self, '_password'):
+            dct['password'] = self._password
+        return dct
+
+    @classmethod
+    def register(
+        cls,
+        name,
+        email_address,
+        mobile_number,
+        password,
+        auth_type,
+    ):
+        return cls(user_api_client.register_user(
+            name,
+            email_address,
+            mobile_number or None,
+            password,
+            auth_type,
+        ))
+
+    def set_password(self, pwd):
+        self._password = pwd
+
+    def send_verify_email(self):
+        user_api_client.send_verify_email(self.id, self.email_address)
+
+    def send_verify_code(self, to=None):
+        user_api_client.send_verify_code(self.id, 'sms', to or self.mobile_number)
+
+    def send_already_registered_email(self):
+        user_api_client.send_already_registered_email(self.id, self.email_address)
+
+    def refresh_session_id(self):
+        self.current_session_id = user_api_client.TODO_get_user(self.id).get('current_session_id')
+        session['current_session_id'] = self.current_session_id
+
+    def add_to_service(self, service_id, permissions, folder_permissions):
+        user_api_client.add_user_to_service(
+            service_id,
+            self.id,
+            permissions,
+            folder_permissions,
+        )
+
+    def add_to_organisation(self, organisation_id):
+        user_api_client.add_user_to_organisation(
+            organisation_id,
+            self.id,
+        )
+
+
+class InvitedUser(JSONModel):
+
+    ALLOWED_PROPERTIES = {
+        'id',
+        'service',
+        'email_address',
+        'permissions',
+        'status',
+        'created_at',
+        'auth_type',
+        'folder_permissions',
+    }
+
+    def __init__(self, _dict):
+        super().__init__(_dict)
+        self.permissions = _dict.get('permissions') or []
+        self._from_user = _dict['from_user']
+
+    @classmethod
+    def create(
+        cls,
+        invite_from_id,
+        service_id,
+        email_address,
+        permissions,
+        auth_type,
+        folder_permissions,
+    ):
+        return cls(invite_api_client.create_invite(
+            invite_from_id,
+            service_id,
+            email_address,
+            permissions,
+            auth_type,
+            folder_permissions,
+        ))
+
+    def accept_invite(self):
+        invite_api_client.accept_invite(self.service, self.id)
+
+    @property
+    def permissions(self):
+        return self._permissions
+
+    @permissions.setter
+    def permissions(self, permissions):
+        if isinstance(permissions, list):
+            self._permissions = permissions
+        else:
+            self._permissions = permissions.split(',')
+        self._permissions = translate_permissions_from_db_to_admin_roles(self.permissions)
+
+    @property
+    def from_user(self):
+        return User.from_id(self._from_user)
+
+    @property
+    def sms_auth(self):
+        return self.auth_type == 'sms_auth'
+
+    @property
+    def email_auth(self):
+        return self.auth_type == 'email_auth'
+
+    @classmethod
+    def from_token(cls, token):
+        try:
+            return cls(invite_api_client.check_token(token))
+        except HTTPError as exception:
+            if exception.status_code == 400 and 'invitation' in exception.message:
+                raise InviteTokenError(exception.message['invitation'])
+            else:
+                raise exception
+
+    @classmethod
+    def from_session(cls):
+        invited_user = session.get('invited_user')
+        return cls(invited_user) if invited_user else None
+
+    def has_permissions(self, *permissions):
+        if self.status == 'cancelled':
+            return False
+        return set(self.permissions) > set(permissions)
+
+    def has_permission_for_service(self, service_id, permission):
+        if self.status == 'cancelled':
+            return False
+        return self.service == service_id and permission in self.permissions
+
+    def __eq__(self, other):
+        return ((self.id,
+                 self.service,
+                 self._from_user,
+                 self.email_address,
+                 self.auth_type,
+                 self.status) == (other.id,
+                                  other.service,
+                                  other._from_user,
+                                  other.email_address,
+                                  other.auth_type,
+                                  other.status))
+
+    def serialize(self, permissions_as_string=False):
+        data = {'id': self.id,
+                'service': self.service,
+                'from_user': self._from_user,
+                'email_address': self.email_address,
+                'status': self.status,
+                'created_at': str(self.created_at),
+                'auth_type': self.auth_type,
+                'folder_permissions': self.folder_permissions
+                }
+        if permissions_as_string:
+            data['permissions'] = ','.join(self.permissions)
+        else:
+            data['permissions'] = sorted(self.permissions)
+        return data
+
+    def template_folders_for_service(self, service=None):
+        # only used on the manage users page to display the count, so okay to not be fully fledged for now
+        return [{'id': x} for x in self.folder_permissions]
+
+
+class InvitedOrgUser(JSONModel):
+
+    ALLOWED_PROPERTIES = {
+        'id',
+        'organisation',
+        'email_address',
+        'status',
+        'created_at',
+    }
+
+    def __init__(self, _dict):
+        super().__init__(_dict)
+        self._invited_by = _dict['invited_by']
+
+    def __eq__(self, other):
+        return ((self.id,
+                 self.organisation,
+                 self._invited_by,
+                 self.email_address,
+                 self.status) == (other.id,
+                                  other.organisation,
+                                  other._invited_by,
+                                  other.email_address,
+                                  other.status))
+
+    @classmethod
+    def create(cls, invite_from_id, org_id, email_address):
+        return cls(org_invite_api_client.create_invite(
+            invite_from_id, org_id, email_address
+        ))
+
+    @classmethod
+    def from_session(cls):
+        invited_org_user = session.get('invited_org_user')
+        return cls(invited_org_user) if invited_org_user else None
+
+    def serialize(self, permissions_as_string=False):
+        data = {'id': self.id,
+                'organisation': self.organisation,
+                'invited_by': self._invited_by,
+                'email_address': self.email_address,
+                'status': self.status,
+                'created_at': str(self.created_at)
+                }
+        return data
+
+    @property
+    def invited_by(self):
+        return User.from_id(self._invited_by)
+
+    @classmethod
+    def from_token(cls, token):
+        try:
+            return cls(org_invite_api_client.check_token(token))
+        except HTTPError as exception:
+            if exception.status_code == 400 and 'invitation' in exception.message:
+                raise InviteTokenError(exception.message['invitation'])
+            else:
+                raise exception
+
+    def accept_invite(self):
+        org_invite_api_client.accept_invite(self.organisation, self.id)
+
+
+class AnonymousUser(AnonymousUserMixin):
+    # set the anonymous user so that if a new browser hits us we don't error http://stackoverflow.com/a/19275188
+
+    def logged_in_elsewhere(self):
+        return False
+
+    @property
+    def default_organisation(self):
+        return Organisation(None)
+
+
+class Users(ModelList):
+
+    client = user_api_client.get_users_for_service
+    model = User
+
+    def __init__(self, service_id):
+        self.items = self.client(service_id)
+
+
+class OrganisationUsers(Users):
+    client = user_api_client.get_users_for_organisation
+
+
+class InvitedUsers(Users):
+
+    client = invite_api_client.get_invites_for_service
+    model = InvitedUser
+
+    def __init__(self, service_id):
+        self.items = [
+            user for user in self.client(service_id)
+            if user['status'] != 'accepted'
+        ]
+
+
+class OrganisationInvitedUsers(InvitedUsers):
+    client = org_invite_api_client.get_invites_for_organisation
+    model = InvitedOrgUser

--- a/admin/app/notify_client/__init__.py
+++ b/admin/app/notify_client/__init__.py
@@ -55,3 +55,7 @@ class NotifyAdminAPIClient(BaseAPIClient):
     def delete(self, *args, **kwargs):
         self.check_inactive_service()
         return super().delete(*args, **kwargs)
+
+
+class InviteTokenError(Exception):
+    pass

--- a/admin/app/notify_client/user_api_client.py
+++ b/admin/app/notify_client/user_api_client.py
@@ -37,6 +37,13 @@ class UserApiClient(NotifyAdminAPIClient):
         user_data = self.post("/user", data)
         return User(user_data['data'], max_failed_login_count=self.max_failed_login_count, max_failed_verify_count=self.max_failed_verify_count)
 
+    # TODO_get_user is the new one, will eventually replace the old one.
+    def TODO_get_user(self, user_id):
+        return self._get_user(user_id)['data']
+
+    def _get_user(self, user_id):
+        return self.get("/user/{}".format(user_id))
+
     def get_user(self, id):
         url = "/user/{}".format(id)
         user_data = self.get(url)
@@ -72,6 +79,9 @@ class UserApiClient(NotifyAdminAPIClient):
         url = "/user/{}".format(user_id)
         user_data = self.post(url, data=data)
         return User(user_data['data'], max_failed_login_count=self.max_failed_login_count, max_failed_verify_count=self.max_failed_verify_count)
+
+    def archive_user(self, user_id):
+        return self.post('/user/{}/archive'.format(user_id), data=None)
 
     def reset_failed_login_count(self, user_id):
         url = "/user/{}/reset-failed-login-count".format(user_id)
@@ -172,6 +182,12 @@ class UserApiClient(NotifyAdminAPIClient):
         endpoint = '/user/reset-password'
         data = {'email': email_address}
         self.post(endpoint, data=data)
+
+    def find_users_by_full_or_partial_email(self, email_address):
+        endpoint = '/user/find-users-by-email'
+        data = {'email': email_address}
+        users = self.post(endpoint, data=data)
+        return users
 
     def is_email_already_in_use(self, email_address):
         if self.get_user_by_email_or_none(email_address):

--- a/admin/app/templates/views/find-users/find-users-by-email.html
+++ b/admin/app/templates/views/find-users/find-users-by-email.html
@@ -1,0 +1,52 @@
+{% extends "views/platform-admin/_base_template.html" %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/form.html" import form_wrapper %}
+
+{% block per_page_title %}
+  Find users by email
+{% endblock %}
+
+{% block platform_admin_content %}
+
+  <h1 class="heading-large">
+    Find users by email
+  </h1>
+
+
+  {% call form_wrapper(
+      action=url_for('.find_users_by_email'),
+      class='grid-row'
+  ) %}
+    <div class="column-three-quarters">
+      {{ textbox(
+        form.search,
+        width='1-1',
+        label='Find users by email, or by partial email'
+      ) }}
+    </div>
+    <div class="column-one-quarter align-button-with-textbox">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <button type="submit" class="button">Search</button>
+    </div>
+  {% endcall %}
+
+  {% call form_wrapper(id='search-form' ) %}
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  {% endcall %}
+
+  {% if users_found %}
+  <nav class="browse-list">
+    <ul>
+    {% for user in users_found %}
+      <li class="browse-list-item">
+        <a href="{{url_for('.user_information', user_id=user.id)}}" class="browse-list-link">{{ user.email_address }}</a>
+        <p class="browse-list-hint">{{ user.name }}</p>
+      </li>
+      <hr>
+    {% endfor %}
+    </ul>
+  </nav>
+  {% elif users_found == [] %}
+    <p class="browse-list-hint">No users found.</p>
+  {% endif %}
+{% endblock %}

--- a/admin/app/templates/views/find-users/user-information.html
+++ b/admin/app/templates/views/find-users/user-information.html
@@ -1,0 +1,72 @@
+{% extends "views/platform-admin/_base_template.html" %}
+{% from "components/page-footer.html" import page_footer %}
+
+{% block per_page_title %}
+  User information for {{ user.name }}
+{% endblock %}
+
+{% block platform_admin_content %}
+  <div class="grid-row bottom-gutter">
+    <div class="column-whole">
+      <h1 class="heading-large">
+        {{ user.name }}
+      </h1>
+      <p>{{ user.email_address }}</p>
+      <p class="{{ '' if user.mobile_number else 'hint' }}">{{ user.mobile_number or 'No mobile number'}}</p>
+      <h2 class="heading-medium">Live services</h2>
+      <nav class="browse-list">
+        {% if user.live_services %}
+          <ul>
+          {% for service in user.live_services %}
+            <li class="browse-list-item">
+              <a class="browse-list-hint" href={{url_for('.service_dashboard', service_id=service.id)}}>{{ service.name }}</a>
+            </li>
+          {% endfor %}
+          </ul>
+        {% else %}
+          <p class="hint">
+            No live services
+          </p>
+        {% endif %}
+      </nav>
+      <h2 class="heading-medium">Trial mode services</h2>
+      <nav class="browse-list">
+        {% if user.trial_mode_services %}
+          <ul>
+          {% for service in user.trial_mode_services %}
+            <li class="browse-list-item">
+              <a class="browse-list-hint" href={{url_for('.service_dashboard', service_id=service.id)}}>{{ service.name }}</a>
+            </li>
+          {% endfor %}
+          </ul>
+        {% else %}
+          <p class="hint">
+            No services in trial mode
+          </p>
+        {% endif %}
+      </nav>
+      <h2 class="heading-medium">Last login</h2>
+      {% if not user.logged_in_at %}
+      <p class="hint">This person has never logged in</p>
+      {% else %}
+      <p>Last logged in
+        <time class="timeago" datetime="{{ user.logged_in_at }}">
+          {{ user.logged_in_at|format_delta }}
+        </time>
+      </p>
+      {% endif %}
+      {% if user.failed_login_count > 0 %}
+      <p style="color:#b10e1e;">
+        {{ user.failed_login_count }} failed login attempts
+      </p>
+      {% endif %}
+      {% if user.state == 'active' %}
+        <span class="page-footer-delete-link page-footer-delete-link-without-button">
+          <a href="{{ url_for('main.archive_user', user_id=user.id) }}">
+            Archive user
+          </a>
+        </span>
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}

--- a/admin/app/templates/views/platform-admin/_base_template.html
+++ b/admin/app/templates/views/platform-admin/_base_template.html
@@ -21,6 +21,7 @@
           ('Email branding', url_for('main.email_branding')),
           ('Letter jobs', url_for('main.letter_jobs')),
           ('Inbound SMS numbers', url_for('main.inbound_sms_admin')),
+          ('Find users by email', url_for('main.find_users_by_email')),
           ('Email complaints', url_for('main.platform_admin_list_complaints'))
         ] %}
           {# Disable letters #}

--- a/admin/tests/app/main/views/test_find_users.py
+++ b/admin/tests/app/main/views/test_find_users.py
@@ -1,0 +1,237 @@
+import pytest
+from bs4 import BeautifulSoup
+from flask import url_for
+from lxml import html
+
+from tests import user_json
+from tests.conftest import normalize_spaces
+
+
+def test_find_users_by_email_page_loads_correctly(client_request, platform_admin_user):
+    client_request.login(platform_admin_user)
+    document = client_request.get('main.find_users_by_email')
+
+    assert document.h1.text.strip() == 'Find users by email'
+    assert len(document.find_all('input', {'type': 'search'})) > 0
+
+
+def test_find_users_by_email_displays_users_found(
+    client_request,
+    platform_admin_user,
+    mocker
+):
+    client_request.login(platform_admin_user)
+    mocker.patch(
+        'app.user_api_client.find_users_by_full_or_partial_email',
+        return_value={"data": [user_json()]},
+        autospec=True,
+    )
+    document = client_request.post(
+        'main.find_users_by_email',
+        _data={"search": "twilight.sparkle"},
+        _expected_status=200
+    )
+
+    assert any(element.text.strip() == 'test@gov.uk' for element in document.find_all(
+        'a', {'class': 'browse-list-link'}, href=True)
+    )
+    assert any(element.text.strip() == 'Test User' for element in document.find_all('p', {'class': 'browse-list-hint'}))
+
+    assert document.find('a', {'class': 'browse-list-link'}).text.strip() == 'test@gov.uk'
+    assert document.find('p', {'class': 'browse-list-hint'}).text.strip() == 'Test User'
+
+
+def test_find_users_by_email_displays_multiple_users(
+    client_request,
+    platform_admin_user,
+    mocker
+):
+    client_request.login(platform_admin_user)
+    mocker.patch(
+        'app.user_api_client.find_users_by_full_or_partial_email',
+        return_value={"data": [user_json(name="Apple Jack"), user_json(name="Apple Bloom")]},
+        autospec=True,
+    )
+    document = client_request.post('main.find_users_by_email', _data={"search": "apple"}, _expected_status=200)
+
+    assert any(
+        element.text.strip() == 'Apple Jack' for element in document.find_all('p', {'class': 'browse-list-hint'})
+    )
+    assert any(
+        element.text.strip() == 'Apple Bloom' for element in document.find_all('p', {'class': 'browse-list-hint'})
+    )
+
+
+def test_find_users_by_email_displays_message_if_no_users_found(
+    client_request,
+    platform_admin_user,
+    mocker
+):
+    client_request.login(platform_admin_user)
+    mocker.patch('app.user_api_client.find_users_by_full_or_partial_email', return_value={"data": []}, autospec=True)
+    document = client_request.post(
+        'main.find_users_by_email', _data={"search": "twilight.sparkle"}, _expected_status=200
+    )
+
+    assert document.find('p', {'class': 'browse-list-hint'}).text.strip() == 'No users found.'
+
+
+def test_find_users_by_email_validates_against_empty_search_submission(
+    client_request,
+    platform_admin_user,
+    mocker
+):
+    client_request.login(platform_admin_user)
+    document = client_request.post('main.find_users_by_email', _data={"search": ""}, _expected_status=400)
+
+    expected_message = "You need to enter full or partial email address to search by."
+    assert document.find('span', {'class': 'error-message'}).text.strip() == expected_message
+
+
+def test_user_information_page_shows_information_about_user(
+    client,
+    platform_admin_user,
+    mocker
+):
+    mocker.patch('app.user_api_client.get_user', side_effect=[
+        platform_admin_user,
+        user_json(name="Apple Bloom", services=[1, 2])
+    ], autospec=True)
+
+    mocker.patch(
+        'app.user_api_client.get_organisations_and_services_for_user',
+        return_value={'organisations': [], 'services': [
+            {"id": 1, "name": "Fresh Orchard Juice", "restricted": True},
+            {"id": 2, "name": "Nature Therapy", "restricted": False},
+        ]},
+        autospec=True
+    )
+    client.login(platform_admin_user)
+    response = client.get(url_for('main.user_information', user_id=345))
+    assert response.status_code == 200
+
+    document = html.fromstring(response.get_data(as_text=True))
+
+    assert document.xpath("//h1/text()[normalize-space()='Apple Bloom']")
+    assert document.xpath("//p/text()[normalize-space()='test@gov.uk']")
+    assert document.xpath("//p/text()[normalize-space()='+447700900986']")
+
+    assert document.xpath("//h2/text()[normalize-space()='Live services']")
+    assert document.xpath("//a/text()[normalize-space()='Nature Therapy']")
+
+    assert document.xpath("//h2/text()[normalize-space()='Trial mode services']")
+    assert document.xpath("//a/text()[normalize-space()='Fresh Orchard Juice']")
+
+    assert document.xpath("//h2/text()[normalize-space()='Last login']")
+    assert not document.xpath("//p/text()[normalize-space()='0 failed login attempts']")
+
+
+def test_user_information_page_displays_if_there_are_failed_login_attempts(
+    client,
+    platform_admin_user,
+    mocker
+):
+    mocker.patch('app.user_api_client.get_user', side_effect=[
+        platform_admin_user,
+        user_json(name="Apple Bloom", failed_login_count=2)
+    ], autospec=True)
+
+    mocker.patch(
+        'app.user_api_client.get_organisations_and_services_for_user',
+        return_value={'organisations': [], 'services': [
+            {"id": 1, "name": "Fresh Orchard Juice", "restricted": True},
+            {"id": 2, "name": "Nature Therapy", "restricted": True},
+        ]},
+        autospec=True
+    )
+    client.login(platform_admin_user)
+    response = client.get(url_for('main.user_information', user_id=345))
+    assert response.status_code == 200
+
+    document = html.fromstring(response.get_data(as_text=True))
+    assert document.xpath("//p/text()[normalize-space()='2 failed login attempts']")
+
+
+def test_user_information_page_shows_archive_link_for_active_users(
+    logged_in_platform_admin_client,
+    api_user_active,
+    mock_get_organisations_and_services_for_user,
+):
+    response = logged_in_platform_admin_client.get(
+        url_for('main.user_information', user_id=api_user_active['id'])
+    )
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    archive_url = url_for('main.archive_user', user_id=api_user_active['id'])
+
+    link = page.find('a', {'href': archive_url})
+    assert normalize_spaces(link.text) == 'Archive user'
+
+
+def test_user_information_page_does_not_show_archive_link_for_inactive_users(
+    mocker,
+    client,
+    platform_admin_user,
+    mock_get_organisations_and_services_for_user,
+):
+    inactive_user = user_json(state='inactive')
+    mocker.patch('app.user_api_client.get_user', side_effect=[platform_admin_user, inactive_user], autospec=True)
+    client.login(platform_admin_user)
+    response = client.get(
+        url_for('main.user_information', user_id=inactive_user['id'])
+    )
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+
+    archive_url = url_for('main.archive_user', user_id=inactive_user['id'])
+    assert not page.find('a', {'href': archive_url})
+
+
+def test_archive_user_prompts_for_confirmation(
+    logged_in_platform_admin_client,
+    api_user_active,
+    mock_get_organisations_and_services_for_user,
+):
+    response = logged_in_platform_admin_client.get(
+        url_for('main.archive_user', user_id=api_user_active['id'])
+    )
+
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert 'Are you sure you want to archive this user?' in page.find('div', class_='banner-dangerous').text
+
+
+def test_archive_user_posts_to_user_client(
+    logged_in_platform_admin_client,
+    api_user_active,
+    mocker,
+    mock_events,
+):
+    mock_user_client = mocker.patch('app.user_api_client.post')
+
+    response = logged_in_platform_admin_client.post(
+        url_for('main.archive_user', user_id=api_user_active['id'])
+    )
+
+    assert response.status_code == 302
+    assert response.location == url_for('main.user_information', user_id=api_user_active['id'], _external=True)
+    mock_user_client.assert_called_once_with('/user/{}/archive'.format(api_user_active['id']), data=None)
+
+    assert mock_events.called
+
+
+def test_archive_user_does_not_create_event_if_user_client_raises_exception(
+    logged_in_platform_admin_client,
+    api_user_active,
+    mocker,
+    mock_events,
+):
+    mock_user_client = mocker.patch('app.user_api_client.post', side_effect=Exception())
+
+    with pytest.raises(Exception):
+        response = logged_in_platform_admin_client.post(
+            url_for('main.archive_user', user_id=api_user_active.id)
+        )
+
+        assert response.status_code == 500
+        assert response.location == url_for('main.user_information', user_id=api_user_active['id'], _external=True)
+        mock_user_client.assert_called_once_with('/user/{}/archive'.format(api_user_active['id']), data=None)
+        assert not mock_events.called


### PR DESCRIPTION
This brings in the bare minimum needed to wire up these pages. The
admin/app/models/*.py files are not all required, but it was easier to
just bring in the entire folder and just disable some parts of it that
imported more things (that would have caused cascading imports).