### PR TITLE
script: add command to get Telstra message status

### DIFF
--- a/api/app/clients/sms/telstra.py
+++ b/api/app/clients/sms/telstra.py
@@ -84,6 +84,12 @@ class TelstraSMSClient(SmsClient):
         req = telstra.ProvisionNumberRequest(active_days=1825)
         telstra_api.create_subscription(req)
 
+    # https://dev.telstra.com/content/messaging-api#operation/Get%20SMS%20Status
+    @timed("Telstra get message status request")
+    def get_message_status(self, message_id):
+        telstra_api = telstra.MessagingApi(self._client)
+        return telstra_api.get_sms_status(message_id=message_id)
+
     # TODO: cache this call. token is valid for 1 hr.
     # https://dev.telstra.com/content/messaging-api#tag/Authentication
     @property


### PR DESCRIPTION
Invoke as:

pipenv run flask command get-telstra-message-status -m <message_id>

If successful, output looks like:

Sent to: +61412345678
Sent at: 2019-09-03T11:09:03+10:00
Received at: 2019-09-03T11:09:21+10:00
Telstra status: DELIVRD
Notify status: delivered

The `Notify status` line is helpful in order to see how Notify has
mapped the Telstra status to our internal status.