### PR TITLE
admin: remove overrides for filenames in table

### DIFF
--- a/admin/app/assets/stylesheets/components/overrides.scss
+++ b/admin/app/assets/stylesheets/components/overrides.scss
@@ -1,9 +1,3 @@
-.file-list-filename.file-list-filename {
-  display: inline-block;
-  padding: 0;
-  margin: 0;
-}
-
 $text-colour: black;
 $text-light: 300;
 $text-normal: 400;
@@ -26,9 +20,11 @@ $button-colour: #00698f;
   font-weight: $text-normal;
 }
 
-*,:after,:before {
+*,
+:after,
+:before {
   background-repeat: no-repeat;
-  box-sizing: border-box
+  box-sizing: border-box;
 }
 
 body,

--- a/admin/app/assets/stylesheets/components/table.scss
+++ b/admin/app/assets/stylesheets/components/table.scss
@@ -232,10 +232,6 @@
   border-bottom: 1px solid $border-colour;
   padding: 10px 0 10px 0;
   text-align: center;
-
-  .table + & {
-    margin-top: -$gutter;
-  }
 }
 
 a.table-show-more-link {


### PR DESCRIPTION
Also remove negative margin on table show more link. With the removal of
the override above the show more link ends up squashing up into the last
row of the table.