### PR TITLE
admin: update gulp-base64, pin Node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,15 @@ version: 2
 references:
   node_image: &node_image
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:10.18.0
 
   python_node_image: &python_node_image
     docker:
-      - image: circleci/python:3.6.5-node
+      - image: circleci/python:3.6.8-node
 
   python_node_postgres_images: &python_node_postgres_images
     docker:
-      - image: circleci/python:3.6.5-node
+      - image: circleci/python:3.6.8-node
       - image: circleci/postgres:9.6-alpine
         environment:
           POSTGRES_USER: circleci
@@ -19,7 +19,7 @@ references:
 
   deploy_image: &deploy_image
     docker:
-      - image: circleci/python:3.6.5-node
+      - image: circleci/python:3.6.8-node
 
   undeploy_image: &undeploy_image
     docker:

--- a/admin/README.md
+++ b/admin/README.md
@@ -11,15 +11,11 @@ Notify admin application.
 
 ## First-time setup
 
-Languages needed
+Languages and tools needed:
 
 - Python 3.6+
-- [Node](https://nodejs.org/) 7.0.0 or greater
-- [yarn](https://yarnpkg.com/en/) 1.15.0 or greater
-
-```shell
-    brew install node
-```
+- [Node](https://nodejs.org/) 10.x
+- [yarn](https://yarnpkg.com/en/)
 
 The app runs within a virtual environment. We use pipenv for easier environment
 management

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,19 +1,26 @@
 {
   "name": "notifications-admin",
+  "private": true,
   "version": "0.0.1",
-  "description": "Admin front end for Notify",
+  "description": "Admin frontend for Notify",
+  "engines": {
+    "node": "^10.x"
+  },
   "scripts": {
     "test": "gulp lint",
     "build": "gulp",
     "watch": "gulp watch"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/alphagov/notifications-admin.git"
-  },
-  "author": "Government Digital Service",
+  "contributors": [
+    {
+      "name": "Government Digital Service"
+    },
+    {
+      "name": "Digital Transformation Agency"
+    }
+  ],
   "license": "MIT",
-  "homepage": "https://github.com/alphagov/notifications-admin#readme",
+  "homepage": "https://github.com/govau/notify/tree/master/admin#readme",
   "dependencies": {
     "@sentry/browser": "^4.6.6",
     "babel-core": "6.26.3",
@@ -40,7 +47,7 @@
     "timeago": "1.6.7"
   },
   "devDependencies": {
-    "gulp-base64": "github:govau/gulp-base64#semver:^1.0",
+    "gulp-base64": "github:govau/gulp-base64#semver:1.0.1",
     "gulp-css-url-adjuster": "0.2.3",
     "gulp-jshint": "2.1.0",
     "gulp-prettyerror": "1.2.1",

--- a/admin/yarn.lock
+++ b/admin/yarn.lock
@@ -1626,11 +1626,6 @@ extend@^3.0.0, extend@~3.0.1, extend@~3.0.2:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
-extend@~1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-1.2.1.tgz#a0f5fd6cfc83a5fe49ef698d60ec8a624dd4576c"
-  integrity sha1-oPX9bPyDpf5J72mNYOyKYk3UV2w=
-
 extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
@@ -2025,13 +2020,12 @@ gulp-babel@7.0.0:
     through2 "^2.0.0"
     vinyl-sourcemaps-apply "^0.2.0"
 
-"gulp-base64@github:govau/gulp-base64#semver:^1.0":
+"gulp-base64@github:govau/gulp-base64#semver:1.0.1":
   version "0.1.3"
   resolved "https://codeload.github.com/govau/gulp-base64/tar.gz/dde118bcb5f0705d7e5a45bda640ed801a53d60e"
   dependencies:
     async "~0.2.10"
     buffers "~0.1.1"
-    extend "~1.2.1"
     mime "^2.3.1"
     request "~2.87.0"
     through2 "~0.4.1"


### PR DESCRIPTION
gulp-base64 was tagged a while back, but we didn't update package.json
to pull in that change.

It was discovered that the Node frontend will not work on 13.x so this
commit also pins it to 10.x. In order for a 10.x to be pulled in by
CircleCI, the circleci/python image needed to be updated to 3.6.8-node.

Also tidy up some fields in package.json.