### PR TITLE
api: ignore IntegrityError in celery task handler

### DIFF
--- a/api/app/celery/reporting_tasks.py
+++ b/api/app/celery/reporting_tasks.py
@@ -10,11 +10,16 @@ from app.models import (Notification,
                         LETTER_TYPE, SMS_TYPE)
 from app import db
 from sqlalchemy import func, desc, case
+from sqlalchemy.exc import IntegrityError
 from notifications_utils.statsd_decorators import statsd
 from app import notify_celery
 from flask import current_app
 from app.utils import convert_utc_to_aet
 from app.dao.fact_notification_status_dao import fetch_notification_status_for_day, update_fact_notification_status
+from app.dao.dao_utils import (
+    transactional,
+    is_duplicate_key_integrity_error,
+)
 
 
 def get_rate(non_letter_rates, letter_rates, notification_type, date, crown=None, rate_multiplier=None):
@@ -32,11 +37,6 @@ def get_rate(non_letter_rates, letter_rates, notification_type, date, crown=None
 def create_nightly_billing():
     yesterday = datetime.utcnow() - timedelta(days=1)
 
-    non_letter_rates = [(r.notification_type, r.valid_from, r.rate) for r in
-                        Rate.query.order_by(desc(Rate.valid_from)).all()]
-    letter_rates = [(r.start_date, r.crown, r.sheet_count, r.rate) for r in
-                    LetterRate.query.order_by(desc(LetterRate.start_date)).all()]
-
     # 3 days of data counting back from yesterday is consolidated.
     for i in range(0, 3):
         process_day = yesterday - timedelta(days=i)
@@ -44,84 +44,105 @@ def create_nightly_billing():
         ds = datetime.combine(process_day, time.min)
         de = datetime.combine(process_day + timedelta(days=1), time.min)
 
-        transit_data = db.session.query(
-            Notification.template_id,
-            Notification.service_id,
-            Notification.notification_type,
-            func.coalesce(Notification.sent_by,
-                          case(
-                              [
-                                  (Notification.notification_type == 'letter', 'dvla'),
-                                  (Notification.notification_type == 'sms', 'unknown'),
-                                  (Notification.notification_type == 'email', 'ses')
-                              ]),
-                          ).label('sent_by'),
-            func.coalesce(Notification.rate_multiplier, 1).label('rate_multiplier'),
-            func.coalesce(Notification.international, False).label('international'),
-            func.sum(Notification.billable_units).label('billable_units'),
-            func.count().label('notifications_sent'),
-            Service.crown,
-        ).filter(
-            Notification.status != NOTIFICATION_CREATED,     # at created status, provider information is not available
-            Notification.status != NOTIFICATION_TECHNICAL_FAILURE,
-            Notification.key_type != KEY_TYPE_TEST,
-            Notification.created_at >= ds,
-            Notification.created_at < de
-        ).group_by(
-            Notification.template_id,
-            Notification.service_id,
-            Notification.notification_type,
-            'sent_by',
-            Notification.rate_multiplier,
-            Notification.international,
-            Service.crown
-        ).join(
-            Service
-        ).all()
+        try:
+            create_nightly_billing_for_day(ds, de)
+        except IntegrityError as e:
+            # SQS is at-least-once message delivery which means this celery
+            # task handler may fire more than once. If there is an
+            # IntegrityError of the duplicate key kind it means that the task
+            # message was delivered more than once.
+            if not is_duplicate_key_integrity_error(e):
+                raise e
 
-        updated_records = 0
-        inserted_records = 0
+            current_app.logger.info(
+                f"Ignoring duplicate key IntegrityError for: process_day: {process_day}, process_day_in_aet: {process_day_in_aet}"
+            )
 
-        for data in transit_data:
-            update_count = FactBilling.query.filter(
-                FactBilling.aet_date == datetime.date(process_day_in_aet),
-                FactBilling.template_id == data.template_id,
-                FactBilling.service_id == data.service_id,
-                FactBilling.provider == data.sent_by,  # This could be zero - this is a bug that needs to be fixed.
-                FactBilling.rate_multiplier == data.rate_multiplier,
-                FactBilling.notification_type == data.notification_type,
-                FactBilling.international == data.international
-            ).update(
-                {"notifications_sent": data.notifications_sent,
-                 "billable_units": data.billable_units},
-                synchronize_session=False)
 
-            if update_count == 0:
-                billing_record = FactBilling(
-                    aet_date=process_day_in_aet,
-                    template_id=data.template_id,
-                    service_id=data.service_id,
-                    notification_type=data.notification_type,
-                    provider=data.sent_by,
-                    rate_multiplier=data.rate_multiplier,
-                    international=data.international,
-                    billable_units=data.billable_units,
-                    notifications_sent=data.notifications_sent,
-                    rate=get_rate(non_letter_rates,
-                                  letter_rates,
-                                  data.notification_type,
-                                  process_day,
-                                  data.crown,
-                                  data.rate_multiplier)
-                )
-                db.session.add(billing_record)
-                inserted_records += 1
+def create_nightly_billing_for_day(process_day, process_day_in_aet, ds, de):
+    non_letter_rates = [(r.notification_type, r.valid_from, r.rate) for r in
+                        Rate.query.order_by(desc(Rate.valid_from)).all()]
+    letter_rates = [(r.start_date, r.crown, r.sheet_count, r.rate) for r in
+                    LetterRate.query.order_by(desc(LetterRate.start_date)).all()]
 
-            updated_records += update_count
-            db.session.commit()
+    transit_data = db.session.query(
+        Notification.template_id,
+        Notification.service_id,
+        Notification.notification_type,
+        func.coalesce(Notification.sent_by,
+                      case(
+                          [
+                              (Notification.notification_type == 'letter', 'dvla'),
+                              (Notification.notification_type == 'sms', 'unknown'),
+                              (Notification.notification_type == 'email', 'ses')
+                          ]),
+                      ).label('sent_by'),
+        func.coalesce(Notification.rate_multiplier, 1).label('rate_multiplier'),
+        func.coalesce(Notification.international, False).label('international'),
+        func.sum(Notification.billable_units).label('billable_units'),
+        func.count().label('notifications_sent'),
+        Service.crown,
+    ).filter(
+        Notification.status != NOTIFICATION_CREATED,     # at created status, provider information is not available
+        Notification.status != NOTIFICATION_TECHNICAL_FAILURE,
+        Notification.key_type != KEY_TYPE_TEST,
+        Notification.created_at >= ds,
+        Notification.created_at < de
+    ).group_by(
+        Notification.template_id,
+        Notification.service_id,
+        Notification.notification_type,
+        'sent_by',
+        Notification.rate_multiplier,
+        Notification.international,
+        Service.crown
+    ).join(
+        Service
+    ).all()
 
-        current_app.logger.info('ft_billing {} to {}: {} rows updated, {} rows inserted'
-                                .format(ds, de, updated_records, inserted_records))
+    updated_records = 0
+    inserted_records = 0
+
+    for data in transit_data:
+        update_count = FactBilling.query.filter(
+            FactBilling.aet_date == datetime.date(process_day_in_aet),
+            FactBilling.template_id == data.template_id,
+            FactBilling.service_id == data.service_id,
+            FactBilling.provider == data.sent_by,  # This could be zero - this is a bug that needs to be fixed.
+            FactBilling.rate_multiplier == data.rate_multiplier,
+            FactBilling.notification_type == data.notification_type,
+            FactBilling.international == data.international
+        ).update(
+            {"notifications_sent": data.notifications_sent,
+                "billable_units": data.billable_units},
+            synchronize_session=False)
+
+        if update_count == 0:
+            billing_record = FactBilling(
+                aet_date=process_day_in_aet,
+                template_id=data.template_id,
+                service_id=data.service_id,
+                notification_type=data.notification_type,
+                provider=data.sent_by,
+                rate_multiplier=data.rate_multiplier,
+                international=data.international,
+                billable_units=data.billable_units,
+                notifications_sent=data.notifications_sent,
+                rate=get_rate(non_letter_rates,
+                              letter_rates,
+                              data.notification_type,
+                              process_day,
+                              data.crown,
+                              data.rate_multiplier)
+            )
+            db.session.add(billing_record)
+            inserted_records += 1
+
+        updated_records += update_count
+        db.session.commit()
+
+    current_app.logger.info('ft_billing {} to {}: {} rows updated, {} rows inserted'
+                            .format(ds, de, updated_records, inserted_records))
 
 
 @notify_celery.task(name="create-nightly-notification-status")
@@ -137,12 +158,29 @@ def create_nightly_notification_status(day_start=None):
     for i in range(0, 4):
         process_day = day_start - timedelta(days=i)
 
-        transit_data = fetch_notification_status_for_day(process_day=process_day)
+        try:
+            fetch_and_update_fact_notification_status(process_day)
+        except IntegrityError as e:
+            # SQS is at-least-once message delivery which means this celery
+            # task handler may fire more than once. If there is an
+            # IntegrityError of the duplicate key kind it means that the task
+            # message was delivered more than once.
+            if not is_duplicate_key_integrity_error(e):
+                raise e
 
-        update_fact_notification_status(transit_data, process_day)
-
-        current_app.logger.info(
-            "create-nightly-notification-status task: {} rows updated for day: {}".format(
-                len(transit_data), process_day
+            current_app.logger.info(
+                f"Ignoring duplicate key IntegrityError for process day: {process_day}"
             )
+
+
+@transactional
+def fetch_and_update_fact_notification_status(process_day):
+    transit_data = fetch_notification_status_for_day(process_day=process_day)
+
+    update_fact_notification_status(transit_data, process_day)
+
+    current_app.logger.info(
+        "create-nightly-notification-status task: {} rows updated for day: {}".format(
+            len(transit_data), process_day
         )
+    )

--- a/api/app/dao/dao_utils.py
+++ b/api/app/dao/dao_utils.py
@@ -38,3 +38,10 @@ def version_class(model_class, history_cls=None):
 
 def dao_rollback():
     db.session.rollback()
+
+
+def is_duplicate_key_integrity_error(e):
+    if hasattr(e, 'orig') and hasattr(e.orig, 'pgerror') and e.orig.pgerror \
+            and ('duplicate key value violates unique constraint' in e.orig.pgerror):
+        return True
+    return False


### PR DESCRIPTION
SQS is at-least-once message delivery which means these celery
task handlers may fire more than once. If there is a duplicate
key IntegrityError it means that the task message was
delivered more than once.