### PR TITLE
api: move back to 1 instance for dev due to limits

### DIFF
--- a/api/manifest-dev.yml
+++ b/api/manifest-dev.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   buildpacks:
     - python_buildpack
-  instances: 4
+  instances: 1
   memory: 512M
   disk_quota: 500MB
   services:


### PR DESCRIPTION
Reaching CF org memory limit. Need to move on so reducing instances to 1. 4 would be better because it means that feature environments are more
like prod, but oh well.