### PR TITLE
celery: split out worker app into 6 groups

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,7 +206,7 @@ jobs:
       # Need the API to be running so that the callback can auto-subscribe.
       - run: make ci.setup-ses-callback
 
-  deploy-dev-celery-worker:
+  deploy-dev-celery-worker-default:
     <<: *deploy_image
     steps:
       - *cf_install
@@ -214,7 +214,57 @@ jobs:
       - *cf_login
       - run: make ci.create-service-psql
       - run: make ci.create-service-redis
-      - run: make api.deploy-dev-celery-worker
+      - run: make api.deploy-dev-celery-worker-default
+
+  deploy-dev-celery-worker-priority:
+    <<: *deploy_image
+    steps:
+      - *cf_install
+      - *attach_workspace
+      - *cf_login
+      - run: make ci.create-service-psql
+      - run: make ci.create-service-redis
+      - run: make api.deploy-dev-celery-worker-priority
+
+  deploy-dev-celery-worker-sender:
+    <<: *deploy_image
+    steps:
+      - *cf_install
+      - *attach_workspace
+      - *cf_login
+      - run: make ci.create-service-psql
+      - run: make ci.create-service-redis
+      - run: make api.deploy-dev-celery-worker-sender
+
+  deploy-dev-celery-worker-callbacks:
+    <<: *deploy_image
+    steps:
+      - *cf_install
+      - *attach_workspace
+      - *cf_login
+      - run: make ci.create-service-psql
+      - run: make ci.create-service-redis
+      - run: make api.deploy-dev-celery-worker-callbacks
+
+  deploy-dev-celery-worker-retrys:
+    <<: *deploy_image
+    steps:
+      - *cf_install
+      - *attach_workspace
+      - *cf_login
+      - run: make ci.create-service-psql
+      - run: make ci.create-service-redis
+      - run: make api.deploy-dev-celery-worker-retrys
+
+  deploy-dev-celery-worker-internal:
+    <<: *deploy_image
+    steps:
+      - *cf_install
+      - *attach_workspace
+      - *cf_login
+      - run: make ci.create-service-psql
+      - run: make ci.create-service-redis
+      - run: make api.deploy-dev-celery-worker-internal
 
   deploy-dev-celery-beat:
     <<: *deploy_image
@@ -251,13 +301,53 @@ jobs:
       - *cf_login_prod
       - run: make api.deploy
 
-  deploy-prod-celery-worker:
+  deploy-prod-celery-worker-default:
     <<: *deploy_image
     steps:
       - *cf_install
       - *attach_workspace
       - *cf_login_prod
-      - run: make api.deploy-celery-worker
+      - run: make api.deploy-celery-worker-default
+
+  deploy-prod-celery-worker-priority:
+    <<: *deploy_image
+    steps:
+      - *cf_install
+      - *attach_workspace
+      - *cf_login_prod
+      - run: make api.deploy-celery-worker-priority
+
+  deploy-prod-celery-worker-sender:
+    <<: *deploy_image
+    steps:
+      - *cf_install
+      - *attach_workspace
+      - *cf_login_prod
+      - run: make api.deploy-celery-worker-sender
+
+  deploy-prod-celery-worker-callbacks:
+    <<: *deploy_image
+    steps:
+      - *cf_install
+      - *attach_workspace
+      - *cf_login_prod
+      - run: make api.deploy-celery-worker-callbacks
+
+  deploy-prod-celery-worker-retrys:
+    <<: *deploy_image
+    steps:
+      - *cf_install
+      - *attach_workspace
+      - *cf_login_prod
+      - run: make api.deploy-celery-worker-retrys
+
+  deploy-prod-celery-worker-internal:
+    <<: *deploy_image
+    steps:
+      - *cf_install
+      - *attach_workspace
+      - *cf_login_prod
+      - run: make api.deploy-celery-worker-internal
 
   deploy-prod-celery-beat:
     <<: *deploy_image
@@ -341,7 +431,27 @@ workflows:
           requires:
             - build-api
 
-      - deploy-dev-celery-worker:
+      - deploy-dev-celery-worker-default:
+          requires:
+            - build-api
+
+      - deploy-dev-celery-worker-priority:
+          requires:
+            - build-api
+
+      - deploy-dev-celery-worker-sender:
+          requires:
+            - build-api
+
+      - deploy-dev-celery-worker-callbacks:
+          requires:
+            - build-api
+
+      - deploy-dev-celery-worker-retrys:
+          requires:
+            - build-api
+
+      - deploy-dev-celery-worker-internal:
           requires:
             - build-api
 
@@ -369,7 +479,12 @@ workflows:
             - check-vulnerabilities
             - deploy-dev-api
             - deploy-dev-admin
-            - deploy-dev-celery-worker
+            - deploy-dev-celery-worker-default
+            - deploy-dev-celery-worker-priority
+            - deploy-dev-celery-worker-sender
+            - deploy-dev-celery-worker-callbacks
+            - deploy-dev-celery-worker-retrys
+            - deploy-dev-celery-worker-internal
             - deploy-dev-celery-beat
             - deploy-dev-docs
 
@@ -383,7 +498,32 @@ workflows:
           requires:
             - unlock-prod-deploy
 
-      - deploy-prod-celery-worker:
+      - deploy-prod-celery-worker-default:
+          <<: *master_branch
+          requires:
+            - unlock-prod-deploy
+
+      - deploy-prod-celery-worker-priority:
+          <<: *master_branch
+          requires:
+            - unlock-prod-deploy
+
+      - deploy-prod-celery-worker-sender:
+          <<: *master_branch
+          requires:
+            - unlock-prod-deploy
+
+      - deploy-prod-celery-worker-callbacks:
+          <<: *master_branch
+          requires:
+            - unlock-prod-deploy
+
+      - deploy-prod-celery-worker-retrys:
+          <<: *master_branch
+          requires:
+            - unlock-prod-deploy
+
+      - deploy-prod-celery-worker-internal:
           <<: *master_branch
           requires:
             - unlock-prod-deploy

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ cf-login-prod:
 
 DIRS        = api admin utils status docs
 TARGETS     = install install-dev build check-vulnerabilities clean deploy deploy-dev test
-API_TARGETS = run-celery-worker run-celery-beat deploy-celery-worker-sender deploy-celery-worker deploy-dev-celery-worker-sender deploy-dev-celery-worker deploy-celery-beat deploy-dev-celery-beat
+API_TARGETS = run-celery-worker run-celery-worker-default run-celery-worker-priority run-celery-worker-sender run-celery-worker-callbacks run-celery-worker-retrys run-celery-worker-internal run-celery-beat deploy-celery-worker-default deploy-celery-worker-priority deploy-celery-worker-sender deploy-celery-worker-callbacks deploy-celery-worker-retrys deploy-celery-worker-internal deploy-dev-celery-worker-default deploy-dev-celery-worker-priority deploy-dev-celery-worker-sender deploy-dev-celery-worker-callbacks deploy-dev-celery-worker-retrys deploy-dev-celery-worker-internal deploy-celery-beat deploy-dev-celery-beat
 CI_TARGETS  = create-service-psql create-service-redis setup-ses-callback
 ANY_TARGETS = $(TARGETS) $(API_TARGETS) $(CI_TARGETS)
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ To start the whole app from nothing, you'll need to run the following in
 different shells.
 
 ```
-make api.run-celery-worker-sender
 make api.run-celery-worker
 make admin.run
 ```

--- a/api/Makefile
+++ b/api/Makefile
@@ -122,7 +122,7 @@ run-celery-events:
 
 run-celery-worker: version-file ## Run background non-sender workers
 	NOTIFY_CELERY_CMD=worker \
-		$(RUNNER) celery -A run_celery.notify_celery worker --loglevel=INFO -O fair
+		$(RUNNER) celery -A run_celery.notify_celery worker --loglevel=INFO
 
 run-celery-beat: version-file ## Run scheduled tasks
 	NOTIFY_CELERY_CMD=beat \

--- a/api/Makefile
+++ b/api/Makefile
@@ -120,9 +120,39 @@ run-celery-events:
 	NOTIFY_CELERY_CMD=events \
 		$(RUNNER) celery -A run_celery.notify_celery events
 
-run-celery-worker: version-file ## Run background non-sender workers
+run-celery-worker: version-file ## Run background workers (all queues, useful for development)
 	NOTIFY_CELERY_CMD=worker \
 		$(RUNNER) celery -A run_celery.notify_celery worker --loglevel=INFO
+
+run-celery-worker-default: version-file ## Run background workers (default implies all other non-dedicated queues)
+	NOTIFY_CELERY_CMD=worker-default \
+		$(RUNNER) celery -A run_celery.notify_celery worker --loglevel=INFO \
+			-X priority-tasks,send-email-tasks,send-sms-tasks,service-callbacks,retry-tasks,notify-internal-tasks
+
+run-celery-worker-priority: version-file ## Run background workers (priority queue)
+	NOTIFY_CELERY_CMD=worker-priority \
+		$(RUNNER) celery -A run_celery.notify_celery worker --loglevel=INFO \
+			-Q priority-tasks
+
+run-celery-worker-sender: version-file ## Run background workers (send email and SMS queues)
+	NOTIFY_CELERY_CMD=worker-sender \
+		$(RUNNER) celery -A run_celery.notify_celery worker --loglevel=INFO \
+			-Q send-email-tasks,send-sms-tasks
+
+run-celery-worker-callbacks: version-file ## Run background workers (service callbacks queue)
+	NOTIFY_CELERY_CMD=worker-callbacks \
+		$(RUNNER) celery -A run_celery.notify_celery worker --loglevel=INFO \
+			-Q service-callbacks
+
+run-celery-worker-retrys: version-file ## Run background workers (retry tasks queue)
+	NOTIFY_CELERY_CMD=worker-retrys \
+		$(RUNNER) celery -A run_celery.notify_celery worker --loglevel=INFO \
+			-Q retry-tasks
+
+run-celery-worker-internal: version-file ## Run background workers (Notify internal tasks queue)
+	NOTIFY_CELERY_CMD=worker-internal \
+		$(RUNNER) celery -A run_celery.notify_celery worker --loglevel=INFO \
+			-Q notify-internal-tasks
 
 run-celery-beat: version-file ## Run scheduled tasks
 	NOTIFY_CELERY_CMD=beat \
@@ -165,11 +195,23 @@ deploy-dev: manifest-vars-$(STG).yml vendor requirements.txt
 
 	$(MAKE) create-sap-oauth2-client
 
-deploy-celery-worker:
-	APP=notify-celery-worker $(MAKE) deploy
+deploy-dev-celery-worker-default:
+	APP=notify-celery-worker-default $(MAKE) deploy-dev
 
-deploy-dev-celery-worker:
-	APP=notify-celery-worker $(MAKE) deploy-dev
+deploy-dev-celery-worker-priority:
+	APP=notify-celery-worker-priority $(MAKE) deploy-dev
+
+deploy-dev-celery-worker-sender:
+	APP=notify-celery-worker-sender $(MAKE) deploy-dev
+
+deploy-dev-celery-worker-callbacks:
+	APP=notify-celery-worker-callbacks $(MAKE) deploy-dev
+
+deploy-dev-celery-worker-retrys:
+	APP=notify-celery-worker-retrys $(MAKE) deploy-dev
+
+deploy-dev-celery-worker-internal:
+	APP=notify-celery-worker-internal $(MAKE) deploy-dev
 
 deploy-celery-beat:
 	APP=notify-celery-beat $(MAKE) deploy
@@ -196,7 +238,10 @@ clean:
 	install install-dev setup-db \
 	setup-test-db test lint fmt tests $(APP_TESTS) $(DAO_TESTS) test-roots \
 	run run-celery-worker run-celery-beat \
-	deploy deploy-api deploy-celery-worker deploy-dev-celery-worker deploy-celery-beat deploy-dev-celery-beat \
+	run-celery-worker-default run-celery-worker-priority run-celery-worker-sender run-celery-worker-callbacks run-celery-worker-retrys run-celery-worker-internal \
+	deploy deploy-api \
+	deploy-dev-celery-worker-default deploy-dev-celery-worker-priority deploy-dev-celery-worker-sender deploy-dev-celery-worker-callbacks deploy-dev-celery-worker-retrys deploy-dev-celery-worker-internal \
+	deploy-celery-beat deploy-dev-celery-beat \
 	run-production \
 	create-migration help clean check-vulnerabilities \
 	create-sap-oauth2-client

--- a/api/Makefile
+++ b/api/Makefile
@@ -122,7 +122,7 @@ run-celery-events:
 
 run-celery-worker: version-file ## Run background non-sender workers
 	NOTIFY_CELERY_CMD=worker \
-		$(RUNNER) celery -A run_celery.notify_celery worker --loglevel=INFO
+		$(RUNNER) celery -A run_celery.notify_celery worker --loglevel=INFO -O fair
 
 run-celery-beat: version-file ## Run scheduled tasks
 	NOTIFY_CELERY_CMD=beat \

--- a/api/manifest-dev.yml
+++ b/api/manifest-dev.yml
@@ -32,15 +32,60 @@ applications:
     env:
       <<: *defaults_env
       CF_APP_NAME: notify-api-((stg))
-  - name: notify-celery-worker-((stg))
+  - name: notify-celery-worker-default-((stg))
     <<: *defaults
     memory: 1G
     health-check-type: process
     no-route: true
-    command: make run-celery-worker
+    command: make run-celery-worker-default
     env:
       <<: *defaults_env
-      CF_APP_NAME: notify-celery-worker-((stg))
+      CF_APP_NAME: notify-celery-worker-default-((stg))
+  - name: notify-celery-worker-priority-((stg))
+    <<: *defaults
+    memory: 750M
+    health-check-type: process
+    no-route: true
+    command: make run-celery-worker-priority
+    env:
+      <<: *defaults_env
+      CF_APP_NAME: notify-celery-worker-priority-((stg))
+  - name: notify-celery-worker-sender-((stg))
+    <<: *defaults
+    memory: 1G
+    health-check-type: process
+    no-route: true
+    command: make run-celery-worker-sender
+    env:
+      <<: *defaults_env
+      CF_APP_NAME: notify-celery-worker-sender-((stg))
+  - name: notify-celery-worker-callbacks-((stg))
+    <<: *defaults
+    memory: 750M
+    health-check-type: process
+    no-route: true
+    command: make run-celery-worker-callbacks
+    env:
+      <<: *defaults_env
+      CF_APP_NAME: notify-celery-worker-callbacks-((stg))
+  - name: notify-celery-worker-retrys-((stg))
+    <<: *defaults
+    memory: 750M
+    health-check-type: process
+    no-route: true
+    command: make run-celery-worker-retrys
+    env:
+      <<: *defaults_env
+      CF_APP_NAME: notify-celery-worker-retrys-((stg))
+  - name: notify-celery-worker-internal-((stg))
+    <<: *defaults
+    memory: 750M
+    health-check-type: process
+    no-route: true
+    command: make run-celery-worker-internal
+    env:
+      <<: *defaults_env
+      CF_APP_NAME: notify-celery-worker-internal-((stg))
   - name: notify-celery-beat-((stg))
     <<: *defaults
     memory: 256M

--- a/api/manifest.yml
+++ b/api/manifest.yml
@@ -31,17 +31,72 @@ applications:
     env:
       <<: *defaults_env
       CF_APP_NAME: notify-api
-  - name: notify-celery-worker
+  - name: notify-celery-worker-default
     <<: *defaults
     instances: 4
     memory: 2G
     health-check-type: process
     no-route: true
-    command: make run-celery-worker
+    command: make run-celery-worker-default
     env:
       <<: *defaults_env
-      CF_APP_NAME: notify-celery-worker
+      CF_APP_NAME: notify-celery-worker-default
       CELERYD_CONCURRENCY: 6
+  - name: notify-celery-worker-priority
+    <<: *defaults
+    instances: 2
+    memory: 1G
+    health-check-type: process
+    no-route: true
+    command: make run-celery-worker-priority
+    env:
+      <<: *defaults_env
+      CF_APP_NAME: notify-celery-worker-priority
+      CELERYD_CONCURRENCY: 4
+  - name: notify-celery-worker-sender
+    <<: *defaults
+    instances: 4
+    memory: 2G
+    health-check-type: process
+    no-route: true
+    command: make run-celery-worker-sender
+    env:
+      <<: *defaults_env
+      CF_APP_NAME: notify-celery-worker-sender
+      CELERYD_CONCURRENCY: 6
+  - name: notify-celery-worker-callbacks
+    <<: *defaults
+    instances: 2
+    memory: 1G
+    health-check-type: process
+    no-route: true
+    command: make run-celery-worker-callbacks
+    env:
+      <<: *defaults_env
+      CF_APP_NAME: notify-celery-worker-callbacks
+      CELERYD_CONCURRENCY: 4
+  - name: notify-celery-worker-retrys
+    <<: *defaults
+    instances: 2
+    memory: 1G
+    health-check-type: process
+    no-route: true
+    command: make run-celery-worker-retrys
+    env:
+      <<: *defaults_env
+      CF_APP_NAME: notify-celery-worker-retrys
+      CELERYD_CONCURRENCY: 6
+  - name: notify-celery-worker-internal
+    <<: *defaults
+    instances: 2
+    memory: 1G
+    health-check-type: process
+    no-route: true
+    command: make run-celery-worker-internal
+    env:
+      <<: *defaults_env
+      CF_APP_NAME: notify-celery-worker-internal
+      CELERYD_CONCURRENCY: 4
   - name: notify-celery-beat
     <<: *defaults
     instances: 1

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -100,7 +100,13 @@ undeploy-%:
 	-$(CF) unbind-service notify-api-f-$* notify-redis-f-$*
 	-$(CF) delete notify-f-$* -f
 	-$(CF) delete notify-api-f-$* -f
-	-$(CF) delete notify-celery-worker-f-$* -f
+	-$(CF) delete notify-celery-worker-f-$* -f # TODO: remove once all cleaned up
+	-$(CF) delete notify-celery-worker-default-f-$* -f
+	-$(CF) delete notify-celery-worker-priority-f-$* -f
+	-$(CF) delete notify-celery-worker-sender-f-$* -f
+	-$(CF) delete notify-celery-worker-callbacks-f-$* -f
+	-$(CF) delete notify-celery-worker-retrys-f-$* -f
+	-$(CF) delete notify-celery-worker-internal-f-$* -f
 	-$(CF) delete notify-celery-beat-f-$* -f
 	-$(CF) delete notify-docs-f-$* -f
 	-$(CF) delete-service notify-psql-f-$* -f

--- a/ci/undeploy_closed_branches.py
+++ b/ci/undeploy_closed_branches.py
@@ -5,7 +5,13 @@ import subprocess
 prefixes = [
     'notify-f-',
     'notify-api-f-',
-    'notify-celery-worker-f-',
+    'notify-celery-worker-f-',  # TODO: remove once all cleaned up
+    'notify-celery-worker-default-f-',
+    'notify-celery-worker-priority-f-',
+    'notify-celery-worker-sender-f-',
+    'notify-celery-worker-callbacks-f-',
+    'notify-celery-worker-retrys-f-',
+    'notify-celery-worker-internal-f-',
     'notify-celery-beat-f-',
     'notify-docs-f-',
     'notify-psql-f-',


### PR DESCRIPTION
The aim of this change is to ensure that bad tasks that end up in
certain queues cannot possibly block other important queues that need to
be processed. It was observed that a service callback task appeared to
starve the workers which resulted in other queues not being processed.
This change splits out the service callbacks into its own worker app.
There is still a chance that a bad service callback task can affect
other good service callbacks and a later commit should explore a fix to
that particular issue. However, this change should reduce the surface
area that such a bug can affect.

The 6 groups of workers introduced in this change are:

- sender: processes tasks to send email and send SMS
- priority: processes priority tasks (most importantly any template in
Notify that is given the priority=true status by platform admin)
- callbacks: processes service callbacks (sending requests to a
service's external webhook URL)
- retrys: processes retrys (it is important this is its own queue because
tasks that end up in retry loops should not be allowed to block or
starve other queues)
- internal: processes Notify internal priority tasks (most importantly
sending 2FA SMS codes)
- default: includes every other non-dedicated queue

See UK setup, for example this line: https://github.com/alphagov/notifications-api/blob/544537791da6d2298d4de136107709417c6b1f78/scripts/paas_app_wrapper.sh#L39