### PR TITLE
docs: undocument use of smoke test ph numbers

### DIFF
--- a/docs/src/content/integration-testing.mdx
+++ b/docs/src/content/integration-testing.mdx
@@ -46,29 +46,24 @@ Messages sent using a test key don’t show up on your dashboard or count agains
 
 By default, all messages sent with a test key will result in a delivered status.
 
-If you want to test failure responses with a test key, use the following numbers and addresses:
+If you want to test failure responses with a test key, use the following addresses:
 
 |                                   |                   |
 | --------------------------------- | ----------------- |
-| 0409000003                        | temporary failure |
-| 0409000002                        | permanent failure |
 | temp-fail@simulator.notify        | temporary failure |
 | perm-fail@simulator.notify        | permanent failure |
 | any other valid number or address | delivered         |
 
 ## Smoke testing your integration
 
-If you need to smoke test your integration with Notify on a regular basis, you should use the smoke test numbers and addresses below.
+If you need to smoke test your integration with Notify on a regular basis, you should use the smoke test addresses below.
 
 |                                    |
 | ---------------------------------- |
-| 0400900000                         |
-| 0400900111                         |
-| 0400900222                         |
 | simulate-delivered@notify.gov.au   |
 | simulate-delivered-2@notify.gov.au |
 | simulate-delivered-3@notify.gov.au |
 
-The smoke test numbers and addresses will immediately return a successful response, but won’t send a real message and won’t produce a delivery receipt. The notification ID is not a real ID, you will not be able to fetch the notification by ID.
+The smoke test addresses will immediately return a successful response, but won’t send a real message and won’t produce a delivery receipt. The notification ID is not a real ID, you will not be able to fetch the notification by ID.
 
-You can use the smoke test numbers and addresses with any type of key. If your smoke tests need to get the status of a message, then use a test key and don’t use these numbers and addresses.
+You can use the smoke test addresses with any type of key. If your smoke tests need to get the status of a message, then use a test key and don’t use these addresses.


### PR DESCRIPTION
until we can get some that we're in control of