### PR TITLE
status: restrict which notifications we check on

### DIFF
--- a/api/app/celery/scheduled_tasks.py
+++ b/api/app/celery/scheduled_tasks.py
@@ -163,13 +163,13 @@ def check_notification_status(
 @statsd(namespace="tasks")
 def check_notifications_status():
     # check notifications stuck at sending for the last 4 hours
-
     four_hours = 60 * 60 * 4
-    sms_to_check = dao_notifications_hung_at_sent(SMS_TYPE, in_last_seconds=four_hours)
-    email_to_check = dao_notifications_hung_at_sent(EMAIL_TYPE, in_last_seconds=four_hours)
-    notifications_to_check = sms_to_check + email_to_check
 
-    for notification in notifications_to_check:
+    def notifications_to_check(notification_types):
+        for notification_type in notification_types:
+            yield from dao_notifications_hung_at_sent(notification_type, in_last_seconds=four_hours)
+
+    for notification in notifications_to_check([SMS_TYPE, EMAIL_TYPE]):
         check_notification_status.apply_async([
             notification.notification_type, notification.sent_by,
             notification.reference,

--- a/api/app/dao/notifications_dao.py
+++ b/api/app/dao/notifications_dao.py
@@ -630,16 +630,17 @@ def dao_get_count_of_letters_to_process_for_date(date_to_process=None):
 def dao_notifications_hung_at_sent(notification_type, in_last_seconds=360):
     since_date = datetime.utcnow() - timedelta(seconds=in_last_seconds)
 
-    notifications = Notification.query.filter(
+    return Notification.query.filter(
         Notification.notification_type == notification_type,
         Notification.created_at >= since_date,
+        Notification.reference != None, # noqa
+        Notification.key_type != KEY_TYPE_TEST,
         or_(
             Notification.status == NOTIFICATION_SENDING,
             Notification.status == NOTIFICATION_PENDING,
             Notification.status == NOTIFICATION_SENT
         )
-    ).all()
-    return notifications
+    )
 
 
 def notifications_not_yet_sent(should_be_sending_after_seconds, notification_type):


### PR DESCRIPTION
no longer include notifications that were sent with a test key or
that have no reference to search for