### PR TITLE
cb-failures: record null service,apikey correctly

### DIFF
--- a/api/app/celery/service_callback_tasks.py
+++ b/api/app/celery/service_callback_tasks.py
@@ -163,9 +163,9 @@ def create_delivery_status_callback_data(notification, service_callback_api):
             notification.updated_at.strftime(DATETIME_FORMAT) if notification.updated_at else None,
         "notification_sent_at": notification.sent_at.strftime(DATETIME_FORMAT) if notification.sent_at else None,
         "notification_type": notification.notification_type,
-        "notification_api_key_id": str(notification.api_key_id),
+        "notification_api_key_id": str(notification.api_key_id) if notification.api_key_id else None,
         "notification_api_key_type": notification.key_type,
-        "service_id": str(notification.service_id),
+        "service_id": str(notification.service_id) if notification.service_id else None,
         "service_callback_api_url": notification.status_callback_url if notification.status_callback_url else service_callback_api.url,
         "service_callback_api_bearer_token": notification.status_callback_bearer_token if notification.status_callback_bearer_token else service_callback_api.bearer_token,
     }


### PR DESCRIPTION
we were attempting to store "None" when we should have stored null.