### PR TITLE
api: expose user creation fields on notifications

### DIFF
--- a/api/app/models.py
+++ b/api/app/models.py
@@ -1426,6 +1426,18 @@ class Notification(db.Model):
             # Currently can only be technical-failure
             return self.status
 
+    def get_created_by_name(self):
+        if self.created_by:
+            return self.created_by.name
+
+        return None
+
+    def get_created_by_email_address(self):
+        if self.created_by:
+            return self.created_by.email_address
+
+        return None
+
     def serialize_for_csv(self):
         created_at_in_aet = convert_utc_to_aet(self.created_at)
         serialized = {
@@ -1464,6 +1476,8 @@ class Notification(db.Model):
             "template": template_dict,
             "body": self.content,
             "subject": self.subject,
+            "created_by_name": self.get_created_by_name(),
+            "created_by_email_address": self.get_created_by_email_address(),
             "created_at": self.created_at.strftime(DATETIME_FORMAT),
             "sent_at": self.sent_at.strftime(DATETIME_FORMAT) if self.sent_at else None,
             "completed_at": self.completed_at(),

--- a/api/tests/app/db.py
+++ b/api/tests/app/db.py
@@ -205,6 +205,7 @@ def create_notification(
     normalised_to=None,
     one_off=False,
     sms_sender_id=None,
+    created_by_id=None,
     reply_to_text=None
 ):
     if created_at is None:
@@ -253,6 +254,7 @@ def create_notification(
         'international': international,
         'phone_prefix': phone_prefix,
         'normalised_to': normalised_to,
+        'created_by_id': created_by_id,
         'reply_to_text': reply_to_text
     }
     notification = Notification(**data)

--- a/api/tests/app/test_model.py
+++ b/api/tests/app/test_model.py
@@ -226,6 +226,28 @@ def test_letter_notification_serializes_with_address(client, sample_letter_notif
     assert res['postcode'] == 'SW1 1AA'
 
 
+def test_notification_serializes_created_by_name_with_no_created_by_id(client, sample_notification):
+    res = sample_notification.serialize()
+    assert res['created_by_name'] is None
+
+
+def test_notification_serializes_created_by_name_with_created_by_id(client, sample_notification, sample_user):
+    sample_notification.created_by_id = sample_user.id
+    res = sample_notification.serialize()
+    assert res['created_by_name'] == sample_user.name
+
+
+def test_notification_serializes_created_by_email_address_with_no_created_by_id(client, sample_notification):
+    res = sample_notification.serialize()
+    assert res['created_by_email_address'] is None
+
+
+def test_notification_serializes_created_by_email_address_with_created_by_id(client, sample_notification, sample_user):
+    sample_notification.created_by_id = sample_user.id
+    res = sample_notification.serialize()
+    assert res['created_by_email_address'] == sample_user.email_address
+
+
 def test_sms_notification_serializes_without_subject(client, sample_template):
     res = sample_template.serialize()
     assert res['subject'] is None

--- a/api/tests/app/v2/notifications/test_get_notifications.py
+++ b/api/tests/app/v2/notifications/test_get_notifications.py
@@ -74,7 +74,9 @@ def test_get_notification_by_id_returns_200(
         "subject": None,
         'sent_at': sample_notification.sent_at,
         'completed_at': sample_notification.completed_at(),
-        'scheduled_for': '2017-05-12T05:15:00.000000Z'
+        'scheduled_for': '2017-05-12T05:15:00.000000Z',
+        "created_by_name": None,
+        "created_by_email_address": None,
     }
 
     assert json_response == expected_response
@@ -124,7 +126,9 @@ def test_get_notification_by_id_with_placeholders_returns_200(
         "subject": "Bob",
         'sent_at': sample_notification.sent_at,
         'completed_at': sample_notification.completed_at(),
-        'scheduled_for': None
+        'scheduled_for': None,
+        "created_by_name": None,
+        "created_by_email_address": None,
     }
 
     assert json_response == expected_response
@@ -147,6 +151,40 @@ def test_get_notification_by_reference_returns_200(client, sample_template):
 
     assert json_response['notifications'][0]['id'] == str(sample_notification_with_reference.id)
     assert json_response['notifications'][0]['reference'] == "some-client-reference"
+
+
+def test_get_notification_by_id_returns_created_by_name_if_notification_created_by_id(
+    client,
+    sample_user,
+    sample_template,
+):
+    sms_notification = create_notification(template=sample_template, created_by_id=sample_user.id)
+
+    auth_header = create_authorization_header(service_id=sms_notification.service_id)
+    response = client.get(
+        path=url_for('v2_notifications.get_notification_by_id', notification_id=sms_notification.id),
+        headers=[('Content-Type', 'application/json'), auth_header]
+    )
+
+    json_response = response.get_json()
+    assert json_response['created_by_name'] == 'Test User'
+
+
+def test_get_notification_by_id_returns_created_by_email_address_if_notification_created_by_id(
+    client,
+    sample_user,
+    sample_template,
+):
+    sms_notification = create_notification(template=sample_template, created_by_id=sample_user.id)
+
+    auth_header = create_authorization_header(service_id=sms_notification.service_id)
+    response = client.get(
+        path=url_for('v2_notifications.get_notification_by_id', notification_id=sms_notification.id),
+        headers=[('Content-Type', 'application/json'), auth_header]
+    )
+
+    json_response = response.get_json()
+    assert json_response['created_by_email_address'] == 'notify@digital.cabinet-office.gov.uk'
 
 
 def test_get_notifications_returns_scheduled_for(client, sample_template):

--- a/docs/src/code-examples/get-message-by-id/dotnet.mdx
+++ b/docs/src/code-examples/get-message-by-id/dotnet.mdx
@@ -9,11 +9,11 @@ Notification notification = client.GetNotificationById(id);
 <Panel label={<H3 appearAs={H5}>Arguments</H3>}>
   <Parameters>
     <Parameter required name="id" kind="String">
-      The ID of the notification. This can be found in the response after sending an email or SMS.
+      The ID of the notification. This can be found in the response after
+      sending an email or SMS.
     </Parameter>
   </Parameters>
 </Panel>
-
 
 <Panel label={<H3 appearAs={H5}>Response</H3>}>
 
@@ -34,6 +34,7 @@ string status;
 Template template;
 string type;
 string createdByName;
+string createdByEmailAddress;
 ```
 
 </Panel>


### PR DESCRIPTION
expose created_by_email_address and created_by_name fields on our
notification endpoints for notificications that have been sent as a
one-off through the Notify admin interface